### PR TITLE
Issue #770. The id of a Patient object should be accessible via an intuitive API function.

### DIFF
--- a/similarity-data-impl/src/main/java/org/phenotips/data/similarity/internal/AbstractPatientSimilarityView.java
+++ b/similarity-data-impl/src/main/java/org/phenotips/data/similarity/internal/AbstractPatientSimilarityView.java
@@ -93,6 +93,17 @@ public abstract class AbstractPatientSimilarityView implements PatientSimilarity
     }
 
     @Override
+    public String getId()
+    {
+        DocumentReference document = this.getDocument();
+        if (document != null) {
+            return document.getName();
+        } else {
+            return null;
+        }
+    }
+
+    @Override
     public DocumentReference getDocument()
     {
         return this.match.getDocument();


### PR DESCRIPTION
Adding missing getId() in classes that implement Patient interface indirectly.
