### PR TITLE
Update Exomiser handling

### DIFF
--- a/scripts/exomiser_cron.py
+++ b/scripts/exomiser_cron.py
@@ -53,7 +53,10 @@ class Settings:
         'exomiser_template': os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                           'exomiser_settings.txt'),
         'attach_subdir': '~this/attachments',
-        'service_url_base': 'http://localhost:8080/bin/get/PhenoTips',
+        'host': 'http://localhost:8080',
+        'clear_cache_url': '/bin/get/PhenoTips/ClearPatientCache',
+        'export_id_url': '/bin/get/PhenomeCentral/ExportIDs',
+        'export_patient_url': '/bin/get/PhenoTips/ExportPatient',
         }
     _settings = {}
     def __init__(self, **kwargs):
@@ -136,14 +139,14 @@ def maybe_gzip_open(filename, *args, **kwargs):
 
 def fetch_patient_data(record_id, settings):
     logging.info('Fetching patient data for {0}'.format(record_id))
-    url = settings['service_url_base'] + '/ExportPatient?id={0}&basicauth=1'.format(record_id)
+    url = '{0}{1}?id={2}&basicauth=1'.format(settings['host'], settings['export_patient_url'], record_id)
     proc = subprocess.Popen(['curl', '-s', '-S', '-u', settings['credentials'], url], stdout=subprocess.PIPE)
     output = proc.communicate()[0]
     return json.loads(output)
 
 def clear_cache(record_id, settings):
     logging.info('Clearing cache for {0}'.format(record_id))
-    url = settings['service_url_base'] + '/ClearPatientCache?id={0}&basicauth=1'.format(record_id)
+    url = '{0}{1}?id={2}&basicauth=1'.format(settings['host'], settings['clear_cache_url'], record_id)
     retcode = subprocess.call(['curl', '-s', '-S', '-u', settings['credentials'], url], stdout=subprocess.PIPE)
     if retcode != 0:
         logging.error('Attempt to clear cache for {0} failed'.format(record_id))
@@ -154,7 +157,7 @@ def fetch_changed_records(settings, since=None):
         fields['since'] = since
 
     logging.info('Fetching records changed since: {0}'.format(since))
-    url = 'http://localhost:8080/bin/get/Sandbox/ExportIDs?basicauth=1'
+    url = '{0}{1}?basicauth=1'.format(settings['host'], settings['export_id_url'])
     command = ['curl', '-s', '-S', '-u', settings['credentials'], url, '--data', urlencode(fields)]
     proc = subprocess.Popen(command, stdout=subprocess.PIPE)
     stdout = proc.communicate()[0]

--- a/scripts/exomiser_cron.py
+++ b/scripts/exomiser_cron.py
@@ -5,7 +5,7 @@ Usage: $0 PHENOTIPS_DIR EXOMISER_JAR CREDENTIALS_FILE
 
 Check all patient VCF file attachments and update Exomiser files accordingly.
 
-PHENOTIPS_DIR: path to the Phenotips installation's data directory (with 'storage' and 'exomiser' subdirectories)
+PHENOTIPS_DIR: path to the PhenoTips installation's data directory (with 'storage' and 'exomiser' subdirectories)
 EXOMISER_JAR: path to Exomiser JAR file
 CREDENTIALS_FILE: file containing PhenoTips ScriptService credentials (one line, in the format: 'username:password')
 """

--- a/similarity-data-api/src/main/java/org/phenotips/data/similarity/Variant.java
+++ b/similarity-data-api/src/main/java/org/phenotips/data/similarity/Variant.java
@@ -105,7 +105,7 @@ public interface Variant extends Comparable<Variant>
      *       }
      * </pre>
      *
-     * @return the data about this value, using the json-lib classe
+     * @return the data about this value, using the json-lib classes
      */
     JSONObject toJSON();
 }

--- a/similarity-data-api/src/main/java/org/phenotips/data/similarity/Variant.java
+++ b/similarity-data-api/src/main/java/org/phenotips/data/similarity/Variant.java
@@ -93,13 +93,6 @@ public interface Variant extends Comparable<Variant>
     String getEffect();
 
     /**
-     * Get the VCF-line equivalent of the variant.
-     *
-     * @return the line of the VCF file without a terminal newline, or null if not available
-     */
-    String toVCFLine();
-
-    /**
      * Retrieve a variant's information in a JSON format. For example:
      *
      * <pre>
@@ -112,7 +105,7 @@ public interface Variant extends Comparable<Variant>
      *       }
      * </pre>
      *
-     * @return the data about this value, using the json-lib classes
+     * @return the data about this value, using the json-lib classe
      */
     JSONObject toJSON();
 }

--- a/similarity-data-impl/src/main/java/org/phenotips/data/similarity/internal/ExomiserVariant.java
+++ b/similarity-data-impl/src/main/java/org/phenotips/data/similarity/internal/ExomiserVariant.java
@@ -107,7 +107,7 @@ public class ExomiserVariant implements Variant
     {
         String chr = chrom.toUpperCase();
 
-        // Standardize without without prefix
+        // Standardize without prefix
         if (chr.startsWith("CHR")) {
             chr = chr.substring(3);
         }

--- a/similarity-data-impl/src/main/java/org/phenotips/data/similarity/internal/PatientGenotype.java
+++ b/similarity-data-impl/src/main/java/org/phenotips/data/similarity/internal/PatientGenotype.java
@@ -146,6 +146,25 @@ public class PatientGenotype
         return null;
     }
 
+    private static Genotype loadPatientGenotype(String id)
+    {
+        File patientDirectory = new File(genotypeDirectory, id);
+        File exome = new File(patientDirectory, id + GENOTYPE_SUFFIX);
+        if (patientDirectory.isDirectory() && exome.isFile()) {
+            try {
+                Reader exomeReader = new FileReader(exome);
+                Genotype genotype = new ExomiserGenotype(exomeReader);
+                logger.info("Loading genotype for " + id + " from: " + exome);
+                return genotype;
+            } catch (FileNotFoundException e) {
+                // No problem
+            } catch (IOException e) {
+                logger.error("Encountered error reading genotype: " + exome);
+            }
+        }
+        return null;
+    }
+
     /**
      * Get the (potentially-cached) Genotype for the patient with the given id.
      *
@@ -165,20 +184,7 @@ public class PatientGenotype
         }
         if (genotype == null && genotypeDirectory != null) {
             // Attempt to load genotype from file
-            File patientDirectory = new File(genotypeDirectory, id);
-            File exome = new File(patientDirectory, id + GENOTYPE_SUFFIX);
-            if (patientDirectory.isDirectory() && exome.isFile()) {
-                try {
-                    Reader reader = new FileReader(exome);
-                    genotype = new ExomiserGenotype(reader);
-                    logger.info("Loaded genotype for " + id + " from: " + exome);
-                } catch (FileNotFoundException e) {
-                    // No problem
-                } catch (IOException e) {
-                    logger.error("Encountered error reading genotype: " + exome);
-                    genotype = null;
-                }
-            }
+            genotype = loadPatientGenotype(id);
             // Cache genotype
             if (genotype != null && genotypeCache != null) {
                 genotypeCache.set(id, genotype);

--- a/similarity-data-impl/src/main/java/org/phenotips/data/similarity/internal/PatientGenotype.java
+++ b/similarity-data-impl/src/main/java/org/phenotips/data/similarity/internal/PatientGenotype.java
@@ -65,7 +65,7 @@ public class PatientGenotype
     private static final String GENOTYPE_SUBDIR = "exomiser";
 
     /** Suffix of patient genotype files. */
-    private static final String GENOTYPE_SUFFIX = ".variants.tsv";
+    private static final String GENOTYPE_SUFFIX = ".variants.tsv.pass";
 
     /** Cache for storing patient genotypes. */
     private static Cache<Genotype> genotypeCache;
@@ -165,8 +165,9 @@ public class PatientGenotype
         }
         if (genotype == null && genotypeDirectory != null) {
             // Attempt to load genotype from file
-            File exome = new File(genotypeDirectory, id + GENOTYPE_SUFFIX);
-            if (exome.isFile()) {
+            File patientDirectory = new File(genotypeDirectory, id);
+            File exome = new File(patientDirectory, id + GENOTYPE_SUFFIX);
+            if (patientDirectory.isDirectory() && exome.isFile()) {
                 try {
                     Reader reader = new FileReader(exome);
                     genotype = new ExomiserGenotype(reader);

--- a/similarity-data-impl/src/main/java/org/phenotips/data/similarity/internal/RestrictedGenotypeSimilarityView.java
+++ b/similarity-data-impl/src/main/java/org/phenotips/data/similarity/internal/RestrictedGenotypeSimilarityView.java
@@ -34,9 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
@@ -51,9 +48,6 @@ public class RestrictedGenotypeSimilarityView implements GenotypeSimilarityView
 {
     /** The number of genes to show in the JSON output. */
     private static final int MAX_GENES_SHOWN = 10;
-
-    /** Logging helper object. */
-    private static Logger logger = LoggerFactory.getLogger(RestrictedGenotypeSimilarityView.class);
 
     /** The matched patient to represent. */
     private Patient match;

--- a/similarity-data-impl/src/test/java/org/phenotips/data/similarity/internal/ExomiserGenotypeTest.java
+++ b/similarity-data-impl/src/test/java/org/phenotips/data/similarity/internal/ExomiserGenotypeTest.java
@@ -20,6 +20,7 @@
 package org.phenotips.data.similarity.internal;
 
 import org.phenotips.data.similarity.Genotype;
+import org.phenotips.data.similarity.Variant;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -35,12 +36,10 @@ import org.junit.Test;
 public class ExomiserGenotypeTest
 {
     private static final String TEST_FILE =
-        "##fileformat=VCFv4.1\n"
-            + "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tGENOTYPE\n"
-            + "chr16\t30748691\t.\tC\tT\t225.0\tPASS\tDP=40;VDB=0.0403;AF1=0.5;AC1=1;DP4=0,16,4,18;MQ=59;FQ=133;PV4=0.12,0.13,1,1;EXOMISER_GENE=SRCAP;EXOMISER_VARIANT_SCORE=0.95;EXOMISER_GENE_PHENO_SCORE=0.8331819;EXOMISER_GENE_VARIANT_SCORE=0.95;EXOMISER_GENE_COMBINED_SCORE=0.98364943;EXOMISER_EFFECT=STOPGAIN\tGT\t0/1\n"
-            + "chrX\t70349991\t.\tG\tT\t4.13\tPASS\tDP=14;VDB=0.0102;AF1=0.4998;AC1=1;DP4=6,6,1,1;MQ=60;FQ=6.2;PV4=1,1,1,0.43;EXOMISER_GENE=MED12;EXOMISER_VARIANT_SCORE=1.0;EXOMISER_GENE_PHENO_SCORE=0.63577175;EXOMISER_GENE_VARIANT_SCORE=1.0;EXOMISER_GENE_COMBINED_SCORE=0.9244368;EXOMISER_EFFECT=MISSENSE\tGT\t0/1\n"
-            + "chr6\t32629935\t.\tC\tG\t27.0\tPASS\tDP=85;VDB=0.0342;AF1=0.5;AC1=1;DP4=45,21,6,12;MQ=39;FQ=30;PV4=0.013,0.016,0.0014,1;EXOMISER_GENE=HLA-DQB1;EXOMISER_VARIANT_SCORE=0.96;EXOMISER_GENE_PHENO_SCORE=0.6184042;EXOMISER_GENE_VARIANT_SCORE=1.0;EXOMISER_GENE_COMBINED_SCORE=0.91082;EXOMISER_EFFECT=MISSENSE\tGT\t0/1\n";
-
+        "#CHROM\tPOS\tREF\tALT\tQUAL\tFILTER\tGENOTYPE\tCOVERAGE\tFUNCTIONAL_CLASS\tHGVS\tEXOMISER_GENE\tCADD(>0.483)\tPOLYPHEN(>0.956|>0.446)\tMUTATIONTASTER(>0.94)\tSIFT(<0.06)\tDBSNP_ID\tMAX_FREQUENCY\tDBSNP_FREQUENCY\tEVS_EA_FREQUENCY\tEVS_AA_FREQUENCY\tEXOMISER_VARIANT_SCORE\tEXOMISER_GENE_PHENO_SCORE\tEXOMISER_GENE_VARIANT_SCORE\tEXOMISER_GENE_COMBINED_SCORE\n" +
+        "chr16\t30748691\tC\tT\t225.0\tPASS\t0/1\t40\tSTOPGAIN\tSRCAP:uc002dzg.1:exon29:c.6715C>T:p.R2239*\tSRCAP\t.\t.\t.\t.\t.\t0.0\t.\t.\t.\t0.95\t0.8603835\t0.95\t0.9876266\n" +
+        "chr1\t120611964\tG\tC\t76.0\tPASS\t0/1\t42\tMISSENSE\tNOTCH2:uc001eil.3:exon1:c.57C>G:p.C19W\tNOTCH2\t6.292\t.\t.\t0.0\t.\t0.0\t.\t.\t.\t1.0\t0.7029731\t1.0\t0.9609373\n" +
+        "chr6\t32628660\tT\tC\t225.0\tPASS\t0/1\t94\tSPLICING\tHLA-DQB1:uc031snx.1:exon5:c.773-1A>G\tHLA-DQB1\t.\t.\t.\t.\t.\t0.0\t.\t.\t.\t0.9\t0.612518\t1.0\t0.9057237\n";
     /** Basic test for Exomiser output file parsing. */
     @Test
     public void testParseExomiser()
@@ -52,7 +51,22 @@ public class ExomiserGenotypeTest
             Assert.fail("Exomiser file parsing resulted in IOException");
         }
         
-        Assert.assertEquals(0.98364943, genotype.getGeneScore("SRCAP"), 0.00001);
+        Assert.assertEquals(0.9876266, genotype.getGeneScore("SRCAP"), 0.00001);
+        
+        // Get top variant and make sure it was parsed correctly
+        Variant v1 = genotype.getTopVariant("SRCAP", 0);
+        Assert.assertEquals("STOPGAIN", v1.getEffect());
+        Assert.assertEquals("16", v1.getChrom());
+        Assert.assertEquals((Integer)30748691, v1.getPosition());
+        Assert.assertEquals("C", v1.getRef());
+        Assert.assertEquals("T", v1.getAlt());
+        Assert.assertEquals("40", v1.getAnnotation("COVERAGE"));
+        Assert.assertFalse(v1.isHomozygous());
+
+        // Try to get second (non-existent) variant
+        Variant v2 = genotype.getTopVariant("SRCAP", 1);
+        Assert.assertNull(v2);
+        
         Assert.assertEquals(3, genotype.getGenes().size());
     }
 }

--- a/similarity-data-impl/src/test/java/org/phenotips/data/similarity/internal/RestrictedGenotypeSimilarityViewTest.java
+++ b/similarity-data-impl/src/test/java/org/phenotips/data/similarity/internal/RestrictedGenotypeSimilarityViewTest.java
@@ -179,7 +179,7 @@ public class RestrictedGenotypeSimilarityViewTest
         JSONArray vars;
         JSONObject v;
         Assert.assertTrue(top.getString("gene").equals("SRCAP"));
-        Assert.assertEquals(top.getDouble("score"), 1.0, 0.00001);
+        Assert.assertTrue(top.getDouble("score") > 0.9);
 
         // Ensure reference only shows score
         JSONObject refVars = top.getJSONObject("reference");
@@ -187,7 +187,7 @@ public class RestrictedGenotypeSimilarityViewTest
         vars = refVars.getJSONArray("variants");
         Assert.assertEquals(1, vars.size());
         v = vars.getJSONObject(0);
-        Assert.assertEquals(1.0, v.getDouble("score"), 0.0001);
+        Assert.assertTrue(v.getDouble("score") > 0.9);
         Assert.assertEquals(1, v.size());
 
         // Ensure match only shows score
@@ -196,7 +196,7 @@ public class RestrictedGenotypeSimilarityViewTest
         vars = matchVars.getJSONArray("variants");
         Assert.assertEquals(1, vars.size());
         v = vars.getJSONObject(0);
-        Assert.assertEquals(1.0, v.getDouble("score"), 0.0001);
+        Assert.assertTrue(v.getDouble("score") > 0.9);
         Assert.assertEquals(1, v.size());
     }
 


### PR DESCRIPTION
- Switched from Exomiser VCF to TSV as input
- Changed to having per-patient Exomiser subdirectories
- Remove toVCFLine() from Variant class API.
- Made candidate gene boost related to number of candidate genes.