### PR TITLE
PN-161: Notifications does not handle contacts for remote matches correctly; also PN-164; PN-165; PN-166; PN-167; PN-169; PN-170; PN-171; PN-173; PN-178

### DIFF
--- a/access-rules/pom.xml
+++ b/access-rules/pom.xml
@@ -38,16 +38,15 @@
       <artifactId>xwiki-commons-component-api</artifactId>
       <version>${xwiki.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-security-api</artifactId>
+      <version>${xwiki.version}</version>
+    </dependency>
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.xwiki.commons</groupId>
       <artifactId>xwiki-commons-tool-test-component</artifactId>
-      <version>${xwiki.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.xwiki.rendering</groupId>
-      <artifactId>xwiki-rendering-api</artifactId>
       <version>${xwiki.version}</version>
       <scope>test</scope>
     </dependency>

--- a/communication/pom.xml
+++ b/communication/pom.xml
@@ -49,6 +49,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>xwiki-platform-users-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.xwiki.commons</groupId>
       <artifactId>xwiki-commons-component-api</artifactId>
       <version>${xwiki.version}</version>
@@ -83,9 +88,18 @@
       <version>${xwiki.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-bridge</artifactId>
+      <version>${xwiki.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.mail</groupId>
+      <artifactId>mail</artifactId>
+      <version>1.4.5</version>
+    </dependency>
+    <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
-      <version>3.6.9.Final</version>
     </dependency>
     <dependency>
       <groupId>org.hibernate.javax.persistence</groupId>

--- a/matching-notification-api/pom.xml
+++ b/matching-notification-api/pom.xml
@@ -54,6 +54,11 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>phenotips-authorization</artifactId>
+      <version>${phenotips.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>patient-access-rules-api</artifactId>
       <version>${phenotips.version}</version>
     </dependency>

--- a/matching-notification-api/pom.xml
+++ b/matching-notification-api/pom.xml
@@ -44,11 +44,6 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>xwiki-translation-manager</artifactId>
-      <version>${phenotips.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.phenotips</groupId>
       <artifactId>patient-contacts</artifactId>
       <version>${phenotips.version}</version>
     </dependency>
@@ -124,9 +119,8 @@
       <version>${xwiki.version}</version>
     </dependency>
     <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
-      <version>3.1</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>
@@ -143,7 +137,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>14.0.1</version>
     </dependency>
     <dependency>
       <groupId>javax.mail</groupId>

--- a/matching-notification-api/pom.xml
+++ b/matching-notification-api/pom.xml
@@ -48,6 +48,11 @@
       <version>${phenotips.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.phenotips</groupId>
+      <artifactId>patient-contacts</artifactId>
+      <version>${phenotips.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.xwiki.commons</groupId>
       <artifactId>xwiki-commons-script</artifactId>
       <version>${xwiki.version}</version>

--- a/matching-notification-api/pom.xml
+++ b/matching-notification-api/pom.xml
@@ -33,17 +33,17 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>org.phenotips</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>patient-similarity-data-api</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.phenotips</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>patient-similarity-search</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.phenotips</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>xwiki-translation-manager</artifactId>
       <version>${phenotips.version}</version>
     </dependency>
@@ -53,8 +53,38 @@
       <version>${phenotips.version}</version>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>component-registry</artifactId>
+      <version>${phenotips.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>patient-access-rules-api</artifactId>
+      <version>${phenotips.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>vocabularies-api</artifactId>
+      <version>${phenotips.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>patient-data-api</artifactId>
+      <version>${phenotips.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.xwiki.commons</groupId>
       <artifactId>xwiki-commons-script</artifactId>
+      <version>${xwiki.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-observation-api</artifactId>
+      <version>${xwiki.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-component-api</artifactId>
       <version>${xwiki.version}</version>
     </dependency>
     <dependency>
@@ -63,9 +93,19 @@
       <version>${xwiki.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-mail-send-api</artifactId>
+      <version>${xwiki.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
-      <version>3.6.9.Final</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate.javax.persistence</groupId>
+      <artifactId>hibernate-jpa-2.0-api</artifactId>
+      <version>1.0.1.Final</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -74,9 +114,41 @@
       <version>${xwiki.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-model</artifactId>
+      <version>${xwiki.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-query-manager</artifactId>
+      <version>${xwiki.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+      <version>3.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20160212</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>14.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.mail</groupId>
+      <artifactId>mail</artifactId>
+      <version>1.4.5</version>
     </dependency>
     <!-- Test dependencies -->
     <dependency>

--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/MatchingNotificationManager.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/MatchingNotificationManager.java
@@ -57,11 +57,11 @@ public interface MatchingNotificationManager
     boolean saveIncomingMatches(List<PatientSimilarityView> similarityViews, String remoteId);
 
     /**
-     * Marks matches with ids in {@code matchesIds} as rejected.
+     * Sets status to all matches with ids in {@code matchesIds} to a passed status string.
      *
-     * @param matchesIds list of ids of matches to mark as rejected
-     * @param rejected whether matches should be set as rejected or unrejected
+     * @param matchesIds list of ids of matches to set status
+     * @param status whether matches should be set as saved, rejected or uncategorized
      * @return true if successful
      */
-    boolean markRejected(List<Long> matchesIds, boolean rejected);
+    boolean setStatus(List<Long> matchesIds, String status);
 }

--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/internal/DefaultMatchingNotificationManager.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/internal/DefaultMatchingNotificationManager.java
@@ -256,7 +256,7 @@ public class DefaultMatchingNotificationManager implements MatchingNotificationM
             this.matchStorageManager.setStatus(session, matches, status);
             successful = this.matchStorageManager.endNotificationMarkingTransaction(session);
         } catch (HibernateException e) {
-            this.logger.error("Error while marking matches {} as " + status, Joiner.on(",").join(matchesIds), e);
+            this.logger.error("Error while marking matches {} as {}", Joiner.on(",").join(matchesIds), status, e);
         }
         return successful;
     }

--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/internal/DefaultMatchingNotificationManager.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/internal/DefaultMatchingNotificationManager.java
@@ -246,17 +246,17 @@ public class DefaultMatchingNotificationManager implements MatchingNotificationM
     }
 
     @Override
-    public boolean markRejected(List<Long> matchesIds, boolean rejected)
+    public boolean setStatus(List<Long> matchesIds, String status)
     {
         boolean successful = false;
         try {
             List<PatientMatch> matches = this.matchStorageManager.loadMatchesByIds(matchesIds);
 
             Session session = this.matchStorageManager.beginNotificationMarkingTransaction();
-            this.matchStorageManager.markRejected(session, matches, rejected);
+            this.matchStorageManager.setStatus(session, matches, status);
             successful = this.matchStorageManager.endNotificationMarkingTransaction(session);
         } catch (HibernateException e) {
-            this.logger.error("Error while marking matches {} as rejected.", Joiner.on(",").join(matchesIds), e);
+            this.logger.error("Error while marking matches {} as " + status, Joiner.on(",").join(matchesIds), e);
         }
         return successful;
     }

--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/internal/DefaultMatchingNotificationManager.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/internal/DefaultMatchingNotificationManager.java
@@ -95,8 +95,14 @@ public class DefaultMatchingNotificationManager implements MatchingNotificationM
             this.logger.debug("Finding matches for patient {}.", patient.getId());
 
             List<PatientMatch> matchesForPatient = this.matchFinderManager.findMatches(patient);
+            if (matchesForPatient.isEmpty()) {
+                continue;
+            }
             this.filterMatchesByScore(matchesForPatient, score);
             this.filterExistingMatches(matchesForPatient);
+            if (matchesForPatient.isEmpty()) {
+                continue;
+            }
             this.matchStorageManager.saveMatches(matchesForPatient);
 
             addedMatches.addAll(matchesForPatient);

--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/match/PatientInMatch.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/match/PatientInMatch.java
@@ -17,6 +17,8 @@
  */
 package org.phenotips.matchingnotification.match;
 
+import org.phenotips.data.Patient;
+
 import java.util.Collection;
 import java.util.Set;
 
@@ -117,4 +119,14 @@ public interface PatientInMatch
      * @return age of onset
      */
     String getAgeOfOnset();
+
+    /**
+     * @return patient if patient is local and exists or null otherwise.
+     */
+    Patient getPatient();
+
+    /**
+     * @return patient href.
+     */
+    String getHref();
 }

--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/match/PatientMatch.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/match/PatientMatch.java
@@ -68,11 +68,11 @@ public interface PatientMatch
     void setNotified();
 
     /**
-     * Marks rejected property of match.
+     * Marks status property of match (saved, rejected or uncategorized).
      *
-     * @param rejected whether match is rejected or not
+     * @param status whether saved, rejected or uncategorized
      */
-    void setRejected(boolean rejected);
+    void setStatus(String status);
 
     /**
      * @return object in JSON format.
@@ -100,9 +100,9 @@ public interface PatientMatch
     String getHref();
 
     /**
-     * @return true only if match is rejected.
+     * @return status of match: saved, rejected or uncategorized.
      */
-    boolean isRejected();
+    String getStatus();
 
     /**
      * Checks if {@code other} is equivalent to this.

--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/match/PatientMatch.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/match/PatientMatch.java
@@ -29,7 +29,7 @@ import org.json.JSONObject;
  */
 public interface PatientMatch
 {
-    /** The space where family data is stored. */
+    /** The space where matches data is stored. */
     EntityReference DATA_SPACE = new EntityReference("MatchingNotification", EntityType.SPACE);
 
     /**
@@ -66,6 +66,13 @@ public interface PatientMatch
      * Marks that notifications regarding this match were sent.
      */
     void setNotified();
+
+    /**
+     * @return true only if match is rejected.
+     * @deprecated use {@link #getStatus()} instead
+     */
+    @Deprecated
+    boolean isRejected();
 
     /**
      * Marks status property of match (saved, rejected or uncategorized).

--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/match/internal/DefaultPatientInMatch.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/match/internal/DefaultPatientInMatch.java
@@ -20,7 +20,6 @@ package org.phenotips.matchingnotification.match.internal;
 import org.phenotips.components.ComponentManagerRegistry;
 import org.phenotips.data.ContactInfo;
 import org.phenotips.data.Patient;
-import org.phenotips.data.PatientContactsManager;
 import org.phenotips.data.PatientData;
 import org.phenotips.data.PatientRepository;
 import org.phenotips.data.similarity.PatientGenotype;
@@ -259,6 +258,7 @@ public class DefaultPatientInMatch implements PatientInMatch
     {
         return this.href;
     }
+
     /*
      * Data read from {@code patientDetails} was exported in {@link getDetailsColumn}. However, it is possible that some
      * data is missing in case more details added in newer versions. So, it is ok for some values to be missing (but not
@@ -307,7 +307,8 @@ public class DefaultPatientInMatch implements PatientInMatch
     }
 
     // convert gene Ensembl IDs to gene symbols with status appended, e.x. 'T (solved)'
-    private Set<String> getGeneSymbols(Set<String> set, String status) {
+    private Set<String> getGeneSymbols(Set<String> set, String status)
+    {
         Set<String> result = new HashSet<>();
         Vocabulary hgnc = VOCABULARY_MANAGER.getVocabulary("HGNC");
         for (String geneEnsemblId : set) {
@@ -352,14 +353,15 @@ public class DefaultPatientInMatch implements PatientInMatch
         }
     }
 
-    private String populateHref(String href) {
+    private String populateHref(String href)
+    {
         // if the patient is remote, we use whatever is passed by from DB
-        if (patient == null) {
+        if (this.patient == null) {
             return href;
         }
-        PatientData<PatientContactsManager> data = this.patient.getData("contact");
-        if (data != null) {
-            ContactInfo contact = data.getValue().getFirst();
+        PatientData<ContactInfo> data = this.patient.getData("contact");
+        if (data != null && data.size() > 0) {
+            ContactInfo contact = data.get(0);
             if (contact != null) {
                 return contact.getUrl();
             }

--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/match/internal/DefaultPatientMatch.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/match/internal/DefaultPatientMatch.java
@@ -18,10 +18,7 @@
 package org.phenotips.matchingnotification.match.internal;
 
 import org.phenotips.components.ComponentManagerRegistry;
-import org.phenotips.data.ContactInfo;
 import org.phenotips.data.Patient;
-import org.phenotips.data.PatientContactsManager;
-import org.phenotips.data.PatientData;
 import org.phenotips.data.PatientRepository;
 import org.phenotips.data.similarity.PatientSimilarityView;
 import org.phenotips.matchingnotification.match.PatientInMatch;
@@ -196,12 +193,10 @@ public class DefaultPatientMatch implements PatientMatch, Lifecycle
         this.phenotypeScore = similarityView.getPhenotypeScore();
         this.genotypeScore = similarityView.getGenotypeScore();
 
-        PatientData<PatientContactsManager> data = similarityView.getData("contact");
-        if (data != null) {
-        	ContactInfo contact = data.getValue().getFirst();
-            if (contact != null) {
-            	this.href = contact.getUrl();
-            }
+        if (this.matchedPatientInMatch.isLocal()) {
+            this.href = this.referencePatientInMatch.getHref();
+        } else {
+            this.href = this.matchedPatientInMatch.getHref();
         }
 
         // Reorder phenotype

--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/match/internal/DefaultPatientMatch.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/match/internal/DefaultPatientMatch.java
@@ -18,7 +18,10 @@
 package org.phenotips.matchingnotification.match.internal;
 
 import org.phenotips.components.ComponentManagerRegistry;
+import org.phenotips.data.ContactInfo;
 import org.phenotips.data.Patient;
+import org.phenotips.data.PatientContactsManager;
+import org.phenotips.data.PatientData;
 import org.phenotips.data.PatientRepository;
 import org.phenotips.data.similarity.PatientSimilarityView;
 import org.phenotips.matchingnotification.match.PatientInMatch;
@@ -193,8 +196,13 @@ public class DefaultPatientMatch implements PatientMatch, Lifecycle
         this.phenotypeScore = similarityView.getPhenotypeScore();
         this.genotypeScore = similarityView.getGenotypeScore();
 
-        // TODO
-        this.href = null;
+        PatientData<PatientContactsManager> data = similarityView.getData("contact");
+        if (data != null) {
+        	ContactInfo contact = data.getValue().getFirst();
+            if (contact != null) {
+            	this.href = contact.getUrl();
+            }
+        }
 
         // Reorder phenotype
         DefaultPhenotypesMap.reorder(

--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/match/internal/DefaultPatientMatch.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/match/internal/DefaultPatientMatch.java
@@ -78,7 +78,7 @@ public class DefaultPatientMatch implements PatientMatch, Lifecycle
     private Timestamp notifiedTimestamp;
 
     @Basic
-    private Boolean rejected;
+    private String status;
 
     @Basic
     private Double score;
@@ -188,7 +188,7 @@ public class DefaultPatientMatch implements PatientMatch, Lifecycle
         this.foundTimestamp = new Timestamp(System.currentTimeMillis());
         this.notifiedTimestamp = null;
         this.notified = false;
-        this.rejected = false;
+        this.status = "uncategorized";
         this.score = similarityView.getScore();
         this.phenotypeScore = similarityView.getPhenotypeScore();
         this.genotypeScore = similarityView.getGenotypeScore();
@@ -216,15 +216,15 @@ public class DefaultPatientMatch implements PatientMatch, Lifecycle
     }
 
     @Override
-    public void setRejected(boolean rejected)
+    public void setStatus(String newStatus)
     {
-        this.rejected = rejected;
+        this.status = newStatus;
     }
 
     @Override
-    public boolean isRejected()
+    public String getStatus()
     {
-        return this.rejected;
+        return this.status;
     }
 
     @Override
@@ -317,7 +317,7 @@ public class DefaultPatientMatch implements PatientMatch, Lifecycle
             this.notifiedTimestamp == null ? "" : sdf.format(this.notifiedTimestamp));
 
         json.put("notified", this.isNotified());
-        json.put("rejected", this.isRejected());
+        json.put("status", this.getStatus());
         json.put("score", this.getScore());
         json.put("genotypicScore", this.getGenotypeScore());
         json.put("phenotypicScore", this.getPhenotypeScore());

--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/match/internal/DefaultPatientMatch.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/match/internal/DefaultPatientMatch.java
@@ -77,6 +77,13 @@ public class DefaultPatientMatch implements PatientMatch, Lifecycle
     @Basic
     private Timestamp notifiedTimestamp;
 
+    /**
+     * @deprecated use {@link status} instead
+     */
+    @Basic
+    @Deprecated
+    private Boolean rejected;
+
     @Basic
     private String status;
 
@@ -213,6 +220,16 @@ public class DefaultPatientMatch implements PatientMatch, Lifecycle
     public Long getId()
     {
         return this.id;
+    }
+
+    /**
+     * @deprecated use {@link status} instead
+     */
+    @Override
+    @Deprecated
+    public boolean isRejected()
+    {
+        return this.rejected;
     }
 
     @Override

--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/notification/internal/DefaultPatientMatchEmail.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/notification/internal/DefaultPatientMatchEmail.java
@@ -178,6 +178,9 @@ public class DefaultPatientMatchEmail implements PatientMatchEmail
             to.setAddress(emailAddress);
             this.mimeMessage.addRecipient(RecipientType.TO, to);
         }
+        InternetAddress bcc = new InternetAddress();
+        bcc.setAddress("qc@phenomecentral.org");
+        this.mimeMessage.addRecipient(RecipientType.BCC, bcc);
     }
 
     @Override

--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/notification/internal/PatientMatchEmailNotifier.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/notification/internal/PatientMatchEmailNotifier.java
@@ -17,8 +17,8 @@
  */
 package org.phenotips.matchingnotification.notification.internal;
 
+import org.phenotips.data.ContactInfo;
 import org.phenotips.data.Patient;
-import org.phenotips.data.PatientContactsManager;
 import org.phenotips.data.PatientData;
 import org.phenotips.matchingnotification.internal.MatchesByPatient;
 import org.phenotips.matchingnotification.match.PatientMatch;
@@ -93,12 +93,15 @@ public class PatientMatchEmailNotifier implements PatientMatchNotifier
     @Override
     public Collection<String> getNotificationEmailsForPatient(Patient patient)
     {
+        List<String> result = new ArrayList<>();
         if (patient != null) {
-            PatientData<PatientContactsManager> data = patient.getData("contact");
-            if (data != null) {
-                return data.getValue().getEmails();
+            PatientData<ContactInfo> data = patient.getData("contact");
+            if (data != null && data.size() > 0) {
+                for (ContactInfo contact : data) {
+                    result.addAll(contact.getEmails());
+                }
             }
         }
-        return Collections.emptyList();
+        return result;
     }
 }

--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/notification/internal/PatientMatchEmailNotifier.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/notification/internal/PatientMatchEmailNotifier.java
@@ -93,11 +93,12 @@ public class PatientMatchEmailNotifier implements PatientMatchNotifier
     @Override
     public Collection<String> getNotificationEmailsForPatient(Patient patient)
     {
-        PatientData<PatientContactsManager> data = patient.getData("contact");
-        if (data != null) {
-            return data.getValue().getEmails();
+        if (patient != null) {
+            PatientData<PatientContactsManager> data = patient.getData("contact");
+            if (data != null) {
+                return data.getValue().getEmails();
+            }
         }
         return Collections.emptyList();
     }
-
 }

--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/notification/internal/PatientMatchEmailNotifier.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/notification/internal/PatientMatchEmailNotifier.java
@@ -18,9 +18,8 @@
 package org.phenotips.matchingnotification.notification.internal;
 
 import org.phenotips.data.Patient;
-import org.phenotips.data.permissions.Owner;
-import org.phenotips.data.permissions.PatientAccess;
-import org.phenotips.data.permissions.PermissionsManager;
+import org.phenotips.data.PatientContactsManager;
+import org.phenotips.data.PatientData;
 import org.phenotips.matchingnotification.internal.MatchesByPatient;
 import org.phenotips.matchingnotification.match.PatientMatch;
 import org.phenotips.matchingnotification.notification.PatientMatchEmail;
@@ -29,7 +28,6 @@ import org.phenotips.matchingnotification.notification.PatientMatchNotifier;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.mail.MailStatus;
-import org.xwiki.model.reference.EntityReference;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -37,17 +35,10 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
-import javax.inject.Inject;
-import javax.inject.Provider;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.xpn.xwiki.XWiki;
-import com.xpn.xwiki.XWikiContext;
-import com.xpn.xwiki.XWikiException;
 
 /**
  * Notifies about patient matches.
@@ -58,12 +49,6 @@ import com.xpn.xwiki.XWikiException;
 @Singleton
 public class PatientMatchEmailNotifier implements PatientMatchNotifier
 {
-    @Inject
-    private PermissionsManager permissionsManager;
-
-    @Inject
-    private Provider<XWikiContext> contextProvider;
-
     private Logger logger = LoggerFactory.getLogger(PatientMatchEmailNotifier.class);
 
     @Override
@@ -108,34 +93,11 @@ public class PatientMatchEmailNotifier implements PatientMatchNotifier
     @Override
     public Collection<String> getNotificationEmailsForPatient(Patient patient)
     {
-        // TODO currently only return owner's email. Add emails from projects the patient belongs to.
-        Collection<String> emails = new LinkedList<>();
-
-        String ownerEmail = this.getOwnerEmail(patient);
-        if (StringUtils.isNotEmpty(ownerEmail)) {
-            emails.add(ownerEmail);
+        PatientData<PatientContactsManager> data = patient.getData("contact");
+        if (data != null) {
+            return data.getValue().getEmails();
         }
-
-        return emails;
+        return Collections.emptyList();
     }
 
-    private String getOwnerEmail(Patient patient)
-    {
-        PatientAccess referenceAccess = this.permissionsManager.getPatientAccess(patient);
-        Owner owner = referenceAccess.getOwner();
-        if (owner == null) {
-            return null;
-        }
-
-        EntityReference ownerUser = owner.getUser();
-
-        XWikiContext context = this.contextProvider.get();
-        XWiki xwiki = context.getWiki();
-        try {
-            return xwiki.getDocument(ownerUser, context).getStringValue("email");
-        } catch (XWikiException e) {
-            this.logger.error("Error reading owner's email for patient {}.", patient.getId(), e);
-        }
-        return null;
-    }
 }

--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/script/MatchingNotificationScriptService.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/script/MatchingNotificationScriptService.java
@@ -32,6 +32,7 @@ import org.xwiki.security.authorization.Right;
 import org.xwiki.users.UserManager;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
@@ -131,8 +132,8 @@ public class MatchingNotificationScriptService implements ScriptService
             return "";
         }
         List<Long> idsList = this.jsonToIdsList(ids);
-        this.matchingNotificationManager.setStatus(idsList, status);
-        return this.successfulIdsToJSON(idsList, idsList).toString();
+        boolean success = this.matchingNotificationManager.setStatus(idsList, status);
+        return this.successfulIdsToJSON(idsList, success ? idsList : Collections.<Long>emptyList()).toString();
     }
 
     /**

--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/script/MatchingNotificationScriptService.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/script/MatchingNotificationScriptService.java
@@ -35,7 +35,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/script/MatchingNotificationScriptService.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/script/MatchingNotificationScriptService.java
@@ -114,10 +114,12 @@ public class MatchingNotificationScriptService implements ScriptService
     }
 
     /**
-     * Marks matches, with ids given in parameter, as saved, rejected or uncategorized.
-     * Example:
-     *    Input: {'ids': ['1,'2','3']}
-     *    Output:{'results': [{id: '1', success: 'true'}, {id: '2', success: 'false'}, {id: '3', success: 'true'}]}
+     * Marks matches, with ids given in parameter, as saved, rejected or uncategorized. Example:
+     *
+     * <pre>
+     * Input: ["1", "2", "3"], "saved"
+     * Output: {"results": [{"id": "1", "success": true}, {"id": "2", "success": false}, {"id": "3", "success": true}]}
+     * </pre>
      *
      * @param ids JSON with list of ids of matches to set status
      * @param status whether the matches should be set as saved, rejected or uncategorized
@@ -134,8 +136,12 @@ public class MatchingNotificationScriptService implements ScriptService
     }
 
     /**
-     * Sends email notifications for each match. Example: Input: {'ids': ['1,'2','3']} Output: {'results': [{id: '1',
-     * success: 'true'}, {id: '2', success: 'false'}, {id: '3', success: 'true'}]}
+     * Sends email notifications for each match. Example:
+     *
+     * <pre>
+     * Input: ["1", "2", "3"]
+     * Output: {"results": [{"id": "1", "success": true}, {"id": "2", "success": false}, {"id": "3", "success": true}]}
+     * </pre>
      *
      * @param ids JSON list of ids of matching that should be notified
      * @return result JSON

--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/script/MatchingNotificationScriptService.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/script/MatchingNotificationScriptService.java
@@ -94,19 +94,19 @@ public class MatchingNotificationScriptService implements ScriptService
     }
 
     /**
-     * Marks matches, with ids given in parameter, as rejected.
+     * Marks matches, with ids given in parameter, as saved, rejected or uncategorized.
      * Example:
      *    Input: {'ids': ['1,'2','3']}
      *    Output:{'results': [{id: '1', success: 'true'}, {id: '2', success: 'false'}, {id: '3', success: 'true'}]}
      *
-     * @param ids JSON with list of ids of matching that should be marked as rejected
-     * @param rejected whether the matches should be rejected or unrejected
+     * @param ids JSON with list of ids of matches to set status
+     * @param status whether the matches should be set as saved, rejected or uncategorized
      * @return result JSON
      */
-    public String rejectMatches(String ids, boolean rejected)
+    public String setStatus(String ids, String status)
     {
         List<Long> idsList = this.jsonToIdsList(ids);
-        this.matchingNotificationManager.markRejected(idsList, rejected);
+        this.matchingNotificationManager.setStatus(idsList, status);
         return this.successfulIdsToJSON(idsList, idsList).toString();
     }
 

--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/script/MatchingNotificationScriptService.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/script/MatchingNotificationScriptService.java
@@ -176,14 +176,15 @@ public class MatchingNotificationScriptService implements ScriptService
     /**
      * Filters out matches that contain non-existing local patients or self-matches.
      */
-    private void filterPatientsFromMatches(List<PatientMatch> matches) {
+    private void filterPatientsFromMatches(List<PatientMatch> matches)
+    {
         ListIterator<PatientMatch> iterator = matches.listIterator();
         while (iterator.hasNext()) {
             PatientMatch match = iterator.next();
             boolean hasNullPatient = (match.getReference().isLocal() && match.getReference().getPatient() == null)
-                    || (match.getMatched().isLocal() && match.getMatched().getPatient() == null);
+                || (match.getMatched().isLocal() && match.getMatched().getPatient() == null);
             boolean isSelfMatch = CollectionUtils.isEqualCollection(match.getReference().getEmails(),
-                    match.getMatched().getEmails());
+                match.getMatched().getEmails());
             if (hasNullPatient || isSelfMatch) {
                 iterator.remove();
             }

--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/storage/MatchStorageManager.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/storage/MatchStorageManager.java
@@ -82,15 +82,15 @@ public interface MatchStorageManager
     boolean markNotified(Session session, List<PatientMatch> matches);
 
     /**
-     * Marks all matches in {@code matches} as rejected. The method required a session created by
+     * Sets status to all matches in {@code matches} to a passed status string. The method required a session created by
      * {@code startNotificationMarkingTransaction}.
      *
      * @param session the transaction session created for marking.
      * @param matches list of matches to mark as notified.
-     * @param rejected whether the matches should be marked as rejected or unrejected
+     * @param status whether the matches should be marked as saved, rejected or uncategorized
      * @return true if successful
      */
-    boolean markRejected(Session session, List<PatientMatch> matches, boolean rejected);
+    boolean setStatus(Session session, List<PatientMatch> matches, String status);
 
     /**
      * Commits the notification marking transaction. See also {@code startNotificationMarkingTransaction} and

--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/storage/internal/DefaultMatchStorageManager.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/storage/internal/DefaultMatchStorageManager.java
@@ -147,10 +147,10 @@ public class DefaultMatchStorageManager implements MatchStorageManager
     }
 
     @Override
-    public boolean markRejected(Session session, List<PatientMatch> matches, boolean rejected)
+    public boolean setStatus(Session session, List<PatientMatch> matches, String status)
     {
         for (PatientMatch match : matches) {
-            match.setRejected(rejected);
+            match.setStatus(status);
             session.update(match);
         }
         return true;

--- a/matching-notification-migrations/pom.xml
+++ b/matching-notification-migrations/pom.xml
@@ -56,17 +56,5 @@
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
     </dependency>
-    <!-- Test dependencies -->
-    <dependency>
-      <groupId>org.xwiki.commons</groupId>
-      <artifactId>xwiki-commons-tool-test-component</artifactId>
-      <version>${xwiki.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/matching-notification-migrations/pom.xml
+++ b/matching-notification-migrations/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.phenotips</groupId>
+    <artifactId>patient-network</artifactId>
+    <version>1.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>matching-notification-migrations</artifactId>
+  <name>PhenoTips - Patient Network - Matching Notification - Migrations</name>
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>matching-notification-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-component-api</artifactId>
+      <version>${xwiki.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-oldcore</artifactId>
+      <version>${xwiki.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-model</artifactId>
+      <version>${xwiki.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-core</artifactId>
+    </dependency>
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-tool-test-component</artifactId>
+      <version>${xwiki.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/matching-notification-migrations/src/main/java/org/phenotips/matchingnotification/internal/R71502PatientNetwork178DataMigration.java
+++ b/matching-notification-migrations/src/main/java/org/phenotips/matchingnotification/internal/R71502PatientNetwork178DataMigration.java
@@ -1,0 +1,117 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/
+ */
+
+package org.phenotips.matchingnotification.internal;
+
+import org.phenotips.matchingnotification.match.PatientMatch;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.model.reference.EntityReferenceSerializer;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.hibernate.HibernateException;
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.slf4j.Logger;
+
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.store.hibernate.HibernateSessionFactory;
+import com.xpn.xwiki.store.migration.DataMigrationException;
+import com.xpn.xwiki.store.migration.XWikiDBVersion;
+import com.xpn.xwiki.store.migration.hibernate.AbstractHibernateDataMigration;
+import com.xpn.xwiki.store.migration.hibernate.HibernateDataMigration;
+
+/**
+ * Migration for PatientNetwork issue PN-178: Create migrator for matches
+ * database to migrate rejected fields to status fields.
+ *
+ * @version $Id$
+ * @since 1.1
+ */
+@Component(roles = { HibernateDataMigration.class })
+@Named("R71502PatientNetwork178")
+@Singleton
+public class R71502PatientNetwork178DataMigration extends AbstractHibernateDataMigration
+{
+    private static final String REJECTED_NAME = "rejected";
+
+    private static final String UNCATEGORIZED_NAME = "uncategorized";
+
+    /** Logging helper object. */
+    @Inject
+    private Logger logger;
+
+    /** Resolves unprefixed document names to the current wiki. */
+    @Inject
+    @Named("current")
+    private DocumentReferenceResolver<String> resolver;
+
+    /** Serializes the PatientMatch class name. */
+    @Inject
+    @Named("compactwiki")
+    private EntityReferenceSerializer<String> serializer;
+
+    /** Handles persistence. */
+    @Inject
+    private HibernateSessionFactory sessionFactory;
+
+    @Override
+    public String getDescription()
+    {
+        return "Change boolean rejected field to string status field.";
+    }
+
+    @Override
+    public XWikiDBVersion getVersion()
+    {
+        return new XWikiDBVersion(71502);
+    }
+
+    @Override
+    public void hibernateMigrate() throws DataMigrationException, XWikiException
+    {
+        Session session = this.sessionFactory.getSessionFactory().openSession();
+        Query q = session.createQuery("from " + PatientMatch.class.getCanonicalName());
+        @SuppressWarnings("unchecked")
+        List<PatientMatch> matches = q.list();
+        Transaction t = session.beginTransaction();
+        try {
+            for (PatientMatch match : matches) {
+                match.setStatus(match.isRejected() ? REJECTED_NAME : UNCATEGORIZED_NAME);
+                session.update(match);
+            }
+            t.commit();
+        } catch (HibernateException ex) {
+            R71502PatientNetwork178DataMigration.this.logger.warn(
+                     "Failed to set status to match object [{}]: {}",
+                     ex.getMessage());
+            if (t != null) {
+                t.rollback();
+            }
+        } finally {
+            session.close();
+        }
+    }
+}

--- a/matching-notification-migrations/src/main/java/org/phenotips/matchingnotification/internal/R71502PatientNetwork178DataMigration.java
+++ b/matching-notification-migrations/src/main/java/org/phenotips/matchingnotification/internal/R71502PatientNetwork178DataMigration.java
@@ -44,8 +44,8 @@ import com.xpn.xwiki.store.migration.hibernate.AbstractHibernateDataMigration;
 import com.xpn.xwiki.store.migration.hibernate.HibernateDataMigration;
 
 /**
- * Migration for PatientNetwork issue PN-178: Create migrator for matches
- * database to migrate rejected fields to status fields.
+ * Migration for PatientNetwork issue PN-178: Create migrator for matches database to migrate rejected fields to status
+ * fields.
  *
  * @version $Id$
  * @since 1.1
@@ -89,6 +89,7 @@ public class R71502PatientNetwork178DataMigration extends AbstractHibernateDataM
         return new XWikiDBVersion(71502);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void hibernateMigrate() throws DataMigrationException, XWikiException
     {
@@ -104,9 +105,8 @@ public class R71502PatientNetwork178DataMigration extends AbstractHibernateDataM
             }
             t.commit();
         } catch (HibernateException ex) {
-            R71502PatientNetwork178DataMigration.this.logger.warn(
-                     "Failed to set status to match object [{}]: {}",
-                     ex.getMessage());
+            R71502PatientNetwork178DataMigration.this.logger.warn("Failed to migrate PatientMatch status: {}",
+                ex.getMessage());
             if (t != null) {
                 t.rollback();
             }

--- a/matching-notification-migrations/src/main/resources/META-INF/components.txt
+++ b/matching-notification-migrations/src/main/resources/META-INF/components.txt
@@ -1,0 +1,1 @@
+org.phenotips.matchingnotification.internal.R71502PatientNetwork178DataMigration

--- a/matching-notification-resources/src/main/resources/resources/uicomponents/matchingNotification/matchesTable.css
+++ b/matching-notification-resources/src/main/resources/resources/uicomponents/matchingNotification/matchesTable.css
@@ -25,7 +25,7 @@
 }
 
 .matches-table .patient-href {
-   margin-left: 3px;
+  margin-left: 3px;
 }
 
 .matches-table .genes-div, .matches-table .age-of-onset-div  {
@@ -62,8 +62,8 @@
 }
 
 #score-filter-div {
-   margin-top: 15px;
-   margin-bottom: 25px;
+  margin-top: 15px;
+  margin-bottom: 25px;
 }
 #find-matches-messages, #show-matches-messages {
   display: inline-block;

--- a/matching-notification-resources/src/main/resources/resources/uicomponents/matchingNotification/matchesTable.css
+++ b/matching-notification-resources/src/main/resources/resources/uicomponents/matchingNotification/matchesTable.css
@@ -21,7 +21,7 @@
 }
 
 .matches-table .patient-div {
-    margin-bottom: 10px;
+  margin-bottom: 10px;
 }
 
 .matches-table .patient-href {
@@ -29,38 +29,50 @@
 }
 
 .matches-table .genes-div, .matches-table .age-of-onset-div  {
-    background: lightgrey;
+  background: lightgrey;
 }
 
 .matches-table .subtitle {
-    margin-bottom: 0px;
-    margin-top: 0px;
-    font-style: oblique;
+  margin-bottom: 0px;
+  margin-top: 0px;
+  font-style: oblique;
 }
 
 .matches-table ul {
-    margin-top: 0px;
-    margin-bottom: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
 }
 
 .matches-table .collapse-gp-div div {
-    padding-top: 5px;
-    padding-left: 5px;
-    padding-bottom: 5px;
+  padding-top: 5px;
+  padding-left: 5px;
+  padding-bottom: 5px;
 }
 
 .matches-table th {
-    white-space: nowrap;
+  white-space: nowrap;
 }
 
 .matches-table td {
-    vertical-align: text-top;
+  vertical-align: text-top;
 }
 
 .matches-table .collapse-gp-tool {
-    white-space: nowrap;
+  white-space: nowrap;
 }
 
-#filter-div {
-   margin-top: 40px;
+#score-filter-div {
+   margin-top: 15px;
+   margin-bottom: 25px;
+}
+#find-matches-messages, #show-matches-messages {
+  display: inline-block;
+  margin-left: 1em;
+  color: green;
+}
+#table-filter-div div {
+  display: inline-block;
+}
+#table-filter-div {
+  margin-bottom: 15px;
 }

--- a/matching-notification-resources/src/main/resources/resources/uicomponents/matchingNotification/matchesTable.js
+++ b/matching-notification-resources/src/main/resources/resources/uicomponents/matchingNotification/matchesTable.js
@@ -44,7 +44,6 @@ define(["jquery", "dynatable"], function($, dyna)
             return ids;
         },
 
-
         setState : function(matchIds, state)
         {
             var strMatchIds = String(matchIds).split(",");
@@ -59,9 +58,6 @@ define(["jquery", "dynatable"], function($, dyna)
                 }
                 if (state.hasOwnProperty('notify')) {
                     match.notify = state.notify;
-                }
-                if (state.hasOwnProperty('rejected')) {
-                    match.rejected = state.rejected;
                 }
                 if (state.hasOwnProperty('status')) {
                     match.status = state.status;
@@ -122,7 +118,7 @@ define(["jquery", "dynatable"], function($, dyna)
 
         _rowWriter : function(rowIndex, record, columns, cellWriter)
         {
-            var trClass = record.rejected ? 'rejected' : '';
+            var trClass = record.status ? 'status' : '';
             switch(record.status) {
                 case 'success':
                     trClass += ' succeed';
@@ -139,8 +135,8 @@ define(["jquery", "dynatable"], function($, dyna)
                     case 'notification':
                         tr += this._getNotificationTd(record);
                         break;
-                    case 'rejection':
-                        tr += this._getRejectionTd(record);
+                    case 'status':
+                        tr += this._getStatusTd(record);
                         break;
                     case 'referencePatient':
                         tr += this._getPatientDetailsTd(record.reference, 'referencePatientTd', record.id);
@@ -170,9 +166,14 @@ define(["jquery", "dynatable"], function($, dyna)
             return '<td><input type="checkbox" class="notify" data-matchid="' + record.id + '" ' + (record.notify ? 'checked ' : '') + '/></td>';
         },
 
-        _getRejectionTd : function(record)
+        _getStatusTd : function(record)
         {
-            return '<td><input type="checkbox" class="reject" data-matchid="' + record.id + '" ' + (record.rejected ? 'checked ' : '') + '/></td>';
+            return '<td>'
+            + '<select class="status" data-matchid="' + record.id +'">'
+            + '<option value="uncategorized" '+ (record.status == "uncategorized" ? ' selected="selected"' : '') + '> </option>'
+            + '<option value="saved" '+ (record.status == "saved" ? ' selected="selected"' : '') + '>saved</option>'
+            + '<option value="rejected" '+ (record.status == "rejected" ? ' selected="selected"' : '') + '>rejected</option>'
+            + '</select></td>';
         },
 
         _simpleCellWriter : function(value)
@@ -193,7 +194,7 @@ define(["jquery", "dynatable"], function($, dyna)
                     td += '<span> (' + patient.serverId + ')</span>';
                 }
             } else { // remote patient
-                td += '<label class="patient-href">' + patient.patientId + '(' + patient.serverId + ')</label>';
+                td += '<label class="patient-href">' + patient.patientId + ' (' + patient.serverId + ')</label>';
             }
             td += '</div>';
 
@@ -317,6 +318,9 @@ define(["jquery", "dynatable"], function($, dyna)
 
         _buildTable : function()
         {
+            if (!this._matches) {
+                return;
+            }
             var matchesToUse = $.grep(this._matches, this._filter || function(match) {return match});
 
             if (this._tableBuilt) {

--- a/matching-notification-ui/pom.xml
+++ b/matching-notification-ui/pom.xml
@@ -36,13 +36,13 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.phenotips</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>matching-notification-api</artifactId>
       <version>${project.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.phenotips</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>matching-notification-resources</artifactId>
       <version>${project.version}</version>
       <scope>runtime</scope>

--- a/matching-notification-ui/src/main/resources/MatchingNotification/NotifiedTable.xml
+++ b/matching-notification-ui/src/main/resources/MatchingNotification/NotifiedTable.xml
@@ -251,7 +251,6 @@ $xwiki.jsfx.use('uicomponents/matchingNotification/notifiedMatchesTable.js', tru
 &lt;table id="notifiedMatchesTable" class="matches-table"&gt;
   &lt;thead&gt;
     &lt;th data-dynatable-column="notification"&gt;&lt;span title="Notification sent" class="fa fa-envelope"/&gt;&lt;/th&gt;
-    &lt;th data-dynatable-column="id"&gt;&lt;span title="Match ID"&gt;ID&lt;/a&gt;&lt;/th&gt;
     &lt;th data-dynatable-column="referencePatient" title="Reference patient"&gt;Patient&lt;/th&gt;
     &lt;th data-dynatable-column="matchedPatient" title="Matched patient"&gt;Matched Patient&lt;/th&gt;
     &lt;th data-dynatable-column="score" title="Match score"&gt;Score&lt;/th&gt;
@@ -260,6 +259,7 @@ $xwiki.jsfx.use('uicomponents/matchingNotification/notifiedMatchesTable.js', tru
     &lt;th data-dynatable-column="referenceEmails" title="Emails for reference patient"&gt;Emails&lt;/th&gt;
     &lt;th data-dynatable-column="matchedEmails" title="Emails to matched patient"&gt;Matched Emails&lt;/th&gt;
     &lt;th data-dynatable-column="notifiedTimestamp" title="Time match was notified at"&gt;Notified&lt;/th&gt;
+    &lt;th data-dynatable-column="id"&gt;&lt;span title="Match ID"&gt;ID&lt;/a&gt;&lt;/th&gt;
   &lt;/thead&gt;
   &lt;tbody&gt;
   &lt;/tbody&gt;

--- a/matching-notification-ui/src/main/resources/MatchingNotification/PatientMatchNotificationEmailTemplate.xml
+++ b/matching-notification-ui/src/main/resources/MatchingNotification/PatientMatchNotificationEmailTemplate.xml
@@ -98,6 +98,9 @@
 #set($space-between-matches = 'margin-top : 25px;')
 #set($disclaimer = 'font-size : 10px;')
 #set($patient-id = 'white-space : no-wrap;')
+#if ("$!subjectPatient.serverId" != "")
+  #set($subjectPatientObj = $services.patients.get($!subjectPatient.patientId))
+#end
 &lt;p&gt;$!services.localization.render('phenotips.matchingNotifications.email.salutation', 'xhtml/1.0')&lt;/p&gt;
 &lt;p&gt;$!services.localization.render('phenotips.matchingNotifications.email.introduction', 'xhtml/1.0', [$matches.size()])&lt;/p&gt;
 #foreach ($match in $matches)
@@ -108,7 +111,7 @@
          &lt;th style="$grey-background $table"&gt;
             &lt;div style="$subheader"&gt;$!services.localization.render('phenotips.matchingNotifications.email.table.yourPatient.label', 'xhtml/1.0')&lt;/div&gt;
             &lt;div style="$patient-id"&gt;
-               &lt;span&gt;$!{escapetool.xml($!subjectPatient.patientId)}&lt;/span&gt;
+               &lt;span&gt;#if($subjectPatientObj)[[$!{escapetool.xml($!subjectPatient.patientId)}&gt;&gt;$subjectPatientObj.document||rel="__blank"]]#else$!{escapetool.xml($!subjectPatient.patientId)}#end&lt;/span&gt;
                &lt;span&gt;$!{escapetool.xml($!subjectPatient.externalId)}&lt;/span&gt;
             &lt;/div&gt;
          &lt;/th&gt;

--- a/matching-notification-ui/src/main/resources/MatchingNotification/RequestHandler.xml
+++ b/matching-notification-ui/src/main/resources/MatchingNotification/RequestHandler.xml
@@ -49,10 +49,10 @@
 #elseif ($request.action == 'send-notifications')
    #set ($ids = $!request.ids)
    $services.matchingNotification.sendNotifications($ids)
-#elseif ($request.action == 'reject-matches')
+#elseif ($request.action == 'set-status')
    #set ($ids = $!request.ids)
-   #set ($reject = $!request.reject)
-   $services.matchingNotification.rejectMatches($ids, $reject)
+   #set ($status = $!request.status)
+   $services.matchingNotification.setStatus($ids, $status)
 #end
 {{/velocity}}</content>
 </xwikidoc>

--- a/matching-notification-ui/src/main/resources/MatchingNotification/UnnotifiedTable.xml
+++ b/matching-notification-ui/src/main/resources/MatchingNotification/UnnotifiedTable.xml
@@ -242,35 +242,23 @@ $xwiki.jsfx.use('uicomponents/matchingNotification/unnotifiedMatchesTable.js', t
   &lt;button id="find-matches-button" type="button"&gt;Go&lt;/button&gt;
   &lt;div id="find-matches-messages"/&gt;
 &lt;/div&gt;
-&lt;div id="filter-div"&gt;
-&lt;div&gt;
+&lt;div id="score-filter-div"&gt;
   &lt;label&gt;Show matches with score over &lt;/label&gt;
   &lt;input id="show-matches-score"/&gt;
   &lt;button id="show-matches-button" type="button"&gt;Go&lt;/button&gt;
   &lt;div id="show-matches-messages"/&gt;
 &lt;/div&gt;
-&lt;div&gt;
-  &lt;input type="checkbox" id="rejected" checked /&gt;
-  Hide rejected
+&lt;div id="table-filter-div"&gt;
+  &lt;div&gt;&lt;input type="checkbox" id="rejected" checked /&gt;Hide rejected&lt;/div&gt;
+  &lt;div&gt;&lt;input type="checkbox" id="saved" /&gt;Hide saved&lt;/div&gt;
+  &lt;div&gt;&lt;input type="checkbox" id="uncategorized" /&gt;Hide uncategorized&lt;/div&gt;
+  &lt;div&gt;&lt;input type="checkbox" id="expand_all" checked/&gt;Expand all&lt;/div&gt;
 &lt;/div&gt;
-&lt;div&gt;
-  &lt;input type="checkbox" id="saved" /&gt;
-  Hide saved
-&lt;/div&gt;
-&lt;div&gt;
-  &lt;input type="checkbox" id="uncategorized" /&gt;
-  Hide uncategorized
-&lt;/div&gt;
-&lt;div&gt;
-  &lt;input type="checkbox" id="expand_all" checked/&gt;
-  Expand all
-&lt;/div&gt;
-&lt;/div&gt;
-&lt;br/&gt;
+&lt;div id="filter-div"&gt;
 &lt;table id="matchesTable" class="matches-table"&gt;
   &lt;thead&gt;
     &lt;th data-dynatable-column="notification"&gt;&lt;span title="Notification sent" class="fa fa-envelope"/&gt;&lt;/th&gt;
-    &lt;th data-dynatable-column="rejection"&gt;&lt;span title="Rejected"/&gt;Reject&lt;/th&gt;
+    &lt;th data-dynatable-column="status"&gt;&lt;span title="Status"/&gt;Status&lt;/th&gt;
     &lt;th data-dynatable-column="referencePatient" title="Reference patient"&gt;Patient&lt;/th&gt;
     &lt;th data-dynatable-column="matchedPatient" title="Matched patient"&gt;Matched Patient&lt;/th&gt;
     &lt;th data-dynatable-column="score" title="Match score"&gt;Score&lt;/th&gt;

--- a/matching-notification-ui/src/main/resources/MatchingNotification/UnnotifiedTable.xml
+++ b/matching-notification-ui/src/main/resources/MatchingNotification/UnnotifiedTable.xml
@@ -250,8 +250,16 @@ $xwiki.jsfx.use('uicomponents/matchingNotification/unnotifiedMatchesTable.js', t
   &lt;div id="show-matches-messages"/&gt;
 &lt;/div&gt;
 &lt;div&gt;
-  &lt;input type="checkbox" id="filter_rejected" checked /&gt;
+  &lt;input type="checkbox" id="rejected" checked /&gt;
   Hide rejected
+&lt;/div&gt;
+&lt;div&gt;
+  &lt;input type="checkbox" id="saved" /&gt;
+  Hide saved
+&lt;/div&gt;
+&lt;div&gt;
+  &lt;input type="checkbox" id="uncategorized" /&gt;
+  Hide uncategorized
 &lt;/div&gt;
 &lt;div&gt;
   &lt;input type="checkbox" id="expand_all" checked/&gt;

--- a/matching-notification-ui/src/main/resources/MatchingNotification/UnnotifiedTable.xml
+++ b/matching-notification-ui/src/main/resources/MatchingNotification/UnnotifiedTable.xml
@@ -251,7 +251,7 @@ $xwiki.jsfx.use('uicomponents/matchingNotification/unnotifiedMatchesTable.js', t
 &lt;/div&gt;
 &lt;div&gt;
   &lt;input type="checkbox" id="filter_rejected" checked /&gt;
-  Hide filtered
+  Hide rejected
 &lt;/div&gt;
 &lt;div&gt;
   &lt;input type="checkbox" id="expand_all" checked/&gt;
@@ -263,7 +263,6 @@ $xwiki.jsfx.use('uicomponents/matchingNotification/unnotifiedMatchesTable.js', t
   &lt;thead&gt;
     &lt;th data-dynatable-column="notification"&gt;&lt;span title="Notification sent" class="fa fa-envelope"/&gt;&lt;/th&gt;
     &lt;th data-dynatable-column="rejection"&gt;&lt;span title="Rejected"/&gt;Reject&lt;/th&gt;
-    &lt;th data-dynatable-column="id"&gt;&lt;span title="Match ID"&gt;ID&lt;/a&gt;&lt;/th&gt;
     &lt;th data-dynatable-column="referencePatient" title="Reference patient"&gt;Patient&lt;/th&gt;
     &lt;th data-dynatable-column="matchedPatient" title="Matched patient"&gt;Matched Patient&lt;/th&gt;
     &lt;th data-dynatable-column="score" title="Match score"&gt;Score&lt;/th&gt;
@@ -272,6 +271,7 @@ $xwiki.jsfx.use('uicomponents/matchingNotification/unnotifiedMatchesTable.js', t
     &lt;th data-dynatable-column="referenceEmails" title="Emails for reference patient"&gt;Emails&lt;/th&gt;
     &lt;th data-dynatable-column="matchedEmails" title="Emails to matched patient"&gt;Matched Emails&lt;/th&gt;
     &lt;th data-dynatable-column="foundTimestamp" title="Time match was found"&gt;Found&lt;/th&gt;
+    &lt;th data-dynatable-column="id"&gt;&lt;span title="Match ID"&gt;ID&lt;/a&gt;&lt;/th&gt;
   &lt;/thead&gt;
   &lt;tbody&gt;
   &lt;/tbody&gt;

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,24 @@
               <method>org.json.JSONObject getOwnerJSON()</method>
               <justification>Removed for better patient contact acces via getData() method.</justification>
             </difference>
+            <difference>
+              <className>org/phenotips/data/similarity/PatientGenotype</className>
+              <differenceType>7012</differenceType>
+              <method>java.lang.String getGenesStatus()</method>
+              <justification>Provide a status of genes stored in the class.</justification>
+            </difference>
+            <difference>
+              <className>org/phenotips/matchingnotification/match/PatientInMatch</className>
+              <differenceType>7012</differenceType>
+              <method>java.lang.String getHref()</method>
+              <justification>Provide a contact url for patient owner.</justification>
+            </difference>
+            <difference>
+              <className>org/phenotips/matchingnotification/match/PatientInMatch</className>
+              <differenceType>7012</differenceType>
+              <method>org.phenotips.data.Patient getPatient()</method>
+              <justification>Provide a patient object of patient in match.</justification>
+            </difference>
           </ignored>
           <excludes>
             <exclude>**/internal/**</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,12 @@
               <method>java.util.List getTopVariants(java.lang.String)</method>
               <justification>Allow to specify _how many_ top variants to return.</justification>
             </difference>
+            <difference>
+              <className>org/phenotips/data/similarity/PatientSimilarityView</className>
+              <differenceType>7002</differenceType>
+              <method>org.json.JSONObject getOwnerJSON()</method>
+              <justification>Removed for better patient contact acces via getData() method.</justification>
+            </difference>
           </ignored>
           <excludes>
             <exclude>**/internal/**</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.phenotips</groupId>
     <artifactId>phenotips-components</artifactId>
-    <version>1.3-milestone-5</version>
+    <version>1.3-SNAPSHOT</version>
     <relativePath />
   </parent>
   <artifactId>patient-network</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,60 @@
               <method>org.phenotips.data.Patient getPatient()</method>
               <justification>Provide a patient object of patient in match.</justification>
             </difference>
+            <difference>
+              <className>org/phenotips/matchingnotification/MatchingNotificationManager</className>
+              <differenceType>7002</differenceType>
+              <method>boolean markRejected(java.util.List, boolean)</method>
+              <justification>Removed in favour setStatus().</justification>
+            </difference>
+            <difference>
+              <className>org/phenotips/matchingnotification/MatchingNotificationManager</className>
+              <differenceType>7012</differenceType>
+              <method>boolean setStatus(java.util.List, java.lang.String)</method>
+              <justification>Added in place of markRejected().</justification>
+            </difference>
+            <difference>
+              <className>org/phenotips/matchingnotification/match/PatientMatch</className>
+              <differenceType>7012</differenceType>
+              <method>java.lang.String getStatus()</method>
+              <justification>Provide a status of the match (rejected, saved or uncategorized).</justification>
+            </difference>
+            <difference>
+              <className>org/phenotips/matchingnotification/match/PatientMatch</className>
+              <differenceType>7002</differenceType>
+              <method>boolean isRejected()</method>
+              <justification>Removed in favour of getStatus().</justification>
+            </difference>
+            <difference>
+              <className>org/phenotips/matchingnotification/match/PatientMatch</className>
+              <differenceType>7002</differenceType>
+              <method>void setRejected(boolean)</method>
+              <justification>Removed in favour of setStatus().</justification>
+            </difference>
+            <difference>
+              <className>org/phenotips/matchingnotification/match/PatientMatch</className>
+              <differenceType>7012</differenceType>
+              <method>void setStatus(java.lang.String)</method>
+              <justification>Added in place of setRejected().</justification>
+            </difference>
+            <difference>
+              <className>org/phenotips/matchingnotification/script/MatchingNotificationScriptService</className>
+              <differenceType>7002</differenceType>
+              <method>java.lang.String rejectMatches(java.lang.String, boolean)</method>
+              <justification>Removed in favour of setStatus().</justification>
+            </difference>
+            <difference>
+              <className>org/phenotips/matchingnotification/storage/MatchStorageManager</className>
+              <differenceType>7002</differenceType>
+              <method>boolean markRejected(org.hibernate.Session, java.util.List, boolean)</method>
+              <justification>Removed in favour of setStatus().</justification>
+            </difference>
+            <difference>
+              <className>org/phenotips/matchingnotification/storage/MatchStorageManager</className>
+              <differenceType>7012</differenceType>
+              <method>boolean setStatus(org.hibernate.Session, java.util.List, java.lang.String)</method>
+              <justification>Added in place of markRejected().</justification>
+            </difference> 
           </ignored>
           <excludes>
             <exclude>**/internal/**</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
     <module>matching-notification-resources</module>
     <module>matching-notification-ui</module>
     <module>matching-notification-api</module>
+    <module>matching-notification-migrations</module>
   </modules>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.phenotips</groupId>
     <artifactId>phenotips-components</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>1.3-rc-3</version>
     <relativePath />
   </parent>
   <artifactId>patient-network</artifactId>

--- a/similarity-data-api/src/main/java/org/phenotips/data/similarity/PatientGenotype.java
+++ b/similarity-data-api/src/main/java/org/phenotips/data/similarity/PatientGenotype.java
@@ -38,9 +38,9 @@ public interface PatientGenotype extends Exome
     boolean hasGenotypeData();
 
     /**
-     * Return a set of the names of candidate genes listed for the patient.
+     * Return a set of the names of either candidate or solved genes listed for the patient.
      *
-     * @return a (potentially-empty) set of the names of candidate genes
+     * @return a (potentially-empty) set of the names of either candidate or solved genes
      */
     Set<String> getCandidateGenes();
 
@@ -52,4 +52,11 @@ public interface PatientGenotype extends Exome
      */
     @Override
     Set<String> getGenes();
+
+    /**
+     * Return a status of genes (solved or candidate) stored in class.
+     *
+     * @return a status of genes
+     */
+    String getGenesStatus();
 }

--- a/similarity-data-api/src/main/java/org/phenotips/data/similarity/PatientSimilarityView.java
+++ b/similarity-data-api/src/main/java/org/phenotips/data/similarity/PatientSimilarityView.java
@@ -22,8 +22,6 @@ import org.phenotips.data.permissions.AccessLevel;
 
 import org.xwiki.stability.Unstable;
 
-import org.json.JSONObject;
-
 /**
  * View of a patient as related to another reference patient.
  *
@@ -46,14 +44,6 @@ public interface PatientSimilarityView extends Patient
      * @return an {@link AccessLevel} value
      */
     AccessLevel getAccess();
-
-    /**
-     * A JSON-formated string containing the matching patient's owners information. "id" key stores owner's username.
-     * "name" key stores owner's full name (First Last).
-     *
-     * @return the name of the owner of the matching patient, or {@code null} if not available
-     */
-    JSONObject getOwnerJSON();
 
     /**
      * For matchable patients, the owner isn't listed, instead an anonymous email contact can be initiated using this

--- a/similarity-data-impl/pom.xml
+++ b/similarity-data-impl/pom.xml
@@ -84,6 +84,11 @@
       <version>${xwiki.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-script</artifactId>
+      <version>${xwiki.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
@@ -95,11 +100,6 @@
     <dependency>
       <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-cache-api</artifactId>
-      <version>${xwiki.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.xwiki.platform</groupId>
-      <artifactId>xwiki-platform-query-manager</artifactId>
       <version>${xwiki.version}</version>
     </dependency>
     <dependency>

--- a/similarity-data-impl/pom.xml
+++ b/similarity-data-impl/pom.xml
@@ -65,6 +65,11 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>patient-contacts</artifactId>
+      <version>${phenotips.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>patient-network-access-rules</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/similarity-data-impl/src/main/java/org/phenotips/data/similarity/internal/AbstractPatientGenotypeSimilarityView.java
+++ b/similarity-data-impl/src/main/java/org/phenotips/data/similarity/internal/AbstractPatientGenotypeSimilarityView.java
@@ -112,4 +112,10 @@ public abstract class AbstractPatientGenotypeSimilarityView extends AbstractExom
             return this.matchGenotype.getTopVariants(gene, k);
         }
     }
+
+    @Override
+    public String getGenesStatus()
+    {
+        return this.matchGenotype.getGenesStatus();
+    }
 }

--- a/similarity-data-impl/src/main/java/org/phenotips/data/similarity/internal/AbstractPatientSimilarityView.java
+++ b/similarity-data-impl/src/main/java/org/phenotips/data/similarity/internal/AbstractPatientSimilarityView.java
@@ -20,7 +20,6 @@ package org.phenotips.data.similarity.internal;
 import org.phenotips.components.ComponentManagerRegistry;
 import org.phenotips.data.ContactInfo;
 import org.phenotips.data.Patient;
-import org.phenotips.data.PatientContactsManager;
 import org.phenotips.data.PatientData;
 import org.phenotips.data.permissions.AccessLevel;
 import org.phenotips.data.similarity.AccessType;
@@ -281,9 +280,9 @@ public abstract class AbstractPatientSimilarityView implements PatientSimilarity
 
     private JSONObject getOwnerJSON()
     {
-        PatientData<PatientContactsManager> data = this.match.getData("contact");
-        if (data != null) {
-            ContactInfo contact = data.getValue().getFirst();
+        PatientData<ContactInfo> data = this.match.getData("contact");
+        if (data != null && data.size() > 0) {
+            ContactInfo contact = data.get(0);
             if (contact != null) {
                 return contact.toJSON();
             }

--- a/similarity-data-impl/src/main/java/org/phenotips/data/similarity/internal/DefaultPatientGenotypeSimilarityView.java
+++ b/similarity-data-impl/src/main/java/org/phenotips/data/similarity/internal/DefaultPatientGenotypeSimilarityView.java
@@ -64,7 +64,6 @@ public class DefaultPatientGenotypeSimilarityView extends AbstractPatientGenotyp
      */
     private static final int MAX_VARIANTS_PER_GENE_REPORTED_IN_JSON = 10;
 
-
     /**
      * Simple constructor passing the {@link #match matched patient}, the {@link #reference reference patient}, and the
      * {@link #access patient access type}.

--- a/similarity-data-impl/src/main/java/org/phenotips/data/similarity/internal/RestrictedPatientSimilarityView.java
+++ b/similarity-data-impl/src/main/java/org/phenotips/data/similarity/internal/RestrictedPatientSimilarityView.java
@@ -90,12 +90,6 @@ public class RestrictedPatientSimilarityView extends DefaultPatientSimilarityVie
     }
 
     @Override
-    public JSONObject getOwnerJSON()
-    {
-        return this.access.isPrivateAccess() ? new JSONObject() : super.getOwnerJSON();
-    }
-
-    @Override
     public Set<? extends Feature> getFeatures()
     {
         if (this.access.isOpenAccess()) {
@@ -131,9 +125,10 @@ public class RestrictedPatientSimilarityView extends DefaultPatientSimilarityVie
     @Override
     public <T> PatientData<T> getData(String name)
     {
-        if (this.access.isOpenAccess()) {
+        if (this.access.isOpenAccess() || (this.access.isLimitedAccess() && "contact".equals(name))) {
             return this.match.getData(name);
         }
+
         return null;
     }
 

--- a/similarity-data-impl/src/test/java/org/phenotips/data/similarity/internal/RestrictedPatientSimilarityViewTest.java
+++ b/similarity-data-impl/src/test/java/org/phenotips/data/similarity/internal/RestrictedPatientSimilarityViewTest.java
@@ -18,16 +18,13 @@
 package org.phenotips.data.similarity.internal;
 
 import org.phenotips.components.ComponentManagerRegistry;
+import org.phenotips.data.ContactInfo;
 import org.phenotips.data.Disorder;
 import org.phenotips.data.Feature;
 import org.phenotips.data.FeatureMetadatum;
 import org.phenotips.data.IndexedPatientData;
 import org.phenotips.data.Patient;
-import org.phenotips.data.PatientContactsManager;
 import org.phenotips.data.PatientData;
-import org.phenotips.data.SimpleValuePatientData;
-import org.phenotips.data.internal.DefaultContactInfo;
-import org.phenotips.data.internal.DefaultPatientContactsManager;
 import org.phenotips.data.permissions.internal.access.NoAccessLevel;
 import org.phenotips.data.permissions.internal.access.OwnerAccessLevel;
 import org.phenotips.data.similarity.AccessType;
@@ -54,7 +51,6 @@ import org.xwiki.component.util.ReflectionUtils;
 import org.xwiki.model.reference.DocumentReference;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -93,7 +89,7 @@ public class RestrictedPatientSimilarityViewTest
 
     /** The name of the owner of the matched patient. */
     private static final String OWNER_1_NAME = "First Last";
-    
+
     /** The name of the owner of the matched patient. */
     private static final String OWNER_1_ID = "ownerId";
 
@@ -175,13 +171,10 @@ public class RestrictedPatientSimilarityViewTest
         when(mockPatient.getId()).thenReturn(PATIENT_1.getName());
         when(mockPatient.getReporter()).thenReturn(USER_1);
 
-        DefaultContactInfo contactInfo = new DefaultContactInfo();
-        contactInfo.setUserId(OWNER_1_ID);
-        contactInfo.setName(OWNER_1_NAME);
-        PatientContactsManager contactInfos = new DefaultPatientContactsManager(mockPatient);
-        doReturn(contactInfo).when(contactInfos).getFirst();
-        doReturn(Arrays.asList(contactInfo)).when(contactInfos).getAll();
-        PatientData<PatientContactsManager> ownerPatientData = new SimpleValuePatientData<>("contact", contactInfos);
+        ContactInfo.Builder contactInfo = new ContactInfo.Builder();
+        contactInfo.withUserId(OWNER_1_ID).withName(OWNER_1_NAME);
+        PatientData<ContactInfo> ownerPatientData =
+            new IndexedPatientData<>("contact", Collections.singletonList(contactInfo.build()));
         doReturn(ownerPatientData).when(mockPatient).getData("contact");
         return mockPatient;
     }
@@ -240,12 +233,12 @@ public class RestrictedPatientSimilarityViewTest
         PatientSimilarityView o = new RestrictedPatientSimilarityView(mockMatch, mockReference, this.limited);
         Assert.assertNull(o.getReporter());
     }
-    
-    /** The referrer's name is used when there is no Owner controller. */		
-    @Test		
-    public void testGetOwnerWithNoOwnerController()		
+
+    /** The referrer's name is used when there is no Owner controller. */
+    @Test
+    public void testGetOwnerWithNoOwnerController()
     {
-	
+
     }
 
     /** The reporter is not disclosed for private patients. */

--- a/similarity-data-impl/src/test/java/org/phenotips/data/similarity/internal/mocks/MockVocabularyTerm.java
+++ b/similarity-data-impl/src/test/java/org/phenotips/data/similarity/internal/mocks/MockVocabularyTerm.java
@@ -49,8 +49,8 @@ public class MockVocabularyTerm implements VocabularyTerm
     public MockVocabularyTerm(String id, Collection<VocabularyTerm> parents)
     {
         this.id = id;
-        this.parents = new HashSet<VocabularyTerm>();
-        this.ancestors = new HashSet<VocabularyTerm>();
+        this.parents = new HashSet<>();
+        this.ancestors = new HashSet<>();
 
         if (parents != null) {
             this.parents.addAll(parents);
@@ -72,8 +72,8 @@ public class MockVocabularyTerm implements VocabularyTerm
     public MockVocabularyTerm(String id, Collection<VocabularyTerm> parents, Collection<VocabularyTerm> ancestors)
     {
         this.id = id;
-        this.parents = new HashSet<VocabularyTerm>();
-        this.ancestors = new HashSet<VocabularyTerm>();
+        this.parents = new HashSet<>();
+        this.ancestors = new HashSet<>();
 
         if (parents != null) {
             this.parents.addAll(parents);
@@ -112,7 +112,7 @@ public class MockVocabularyTerm implements VocabularyTerm
     @Override
     public Set<VocabularyTerm> getAncestorsAndSelf()
     {
-        Set<VocabularyTerm> result = new LinkedHashSet<VocabularyTerm>();
+        Set<VocabularyTerm> result = new LinkedHashSet<>();
         result.add(this);
         result.addAll(this.ancestors);
         return result;
@@ -149,5 +149,23 @@ public class MockVocabularyTerm implements VocabularyTerm
     public JSONObject toJSON()
     {
         return new JSONObject();
+    }
+
+    @Override
+    public String getTranslatedName()
+    {
+        return getName();
+    }
+
+    @Override
+    public String getTranslatedDescription()
+    {
+        return getDescription();
+    }
+
+    @Override
+    public Collection<?> getTranslatedValues(String name)
+    {
+        return null;
     }
 }

--- a/similarity-search/pom.xml
+++ b/similarity-search/pom.xml
@@ -44,6 +44,11 @@
       <version>${phenotips.version}</version>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>vocabularies-api</artifactId>
+      <version>${phenotips.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.solr</groupId>
       <artifactId>solr-solrj</artifactId>
       <version>${solr.version}</version>
@@ -51,11 +56,6 @@
     <dependency>
       <groupId>org.xwiki.commons</groupId>
       <artifactId>xwiki-commons-component-api</artifactId>
-      <version>${xwiki.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.xwiki.commons</groupId>
-      <artifactId>xwiki-commons-configuration-api</artifactId>
       <version>${xwiki.version}</version>
     </dependency>
     <dependency>
@@ -71,6 +71,11 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.solr</groupId>
+      <artifactId>solr-core</artifactId>
+      <version>${solr.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -31,27 +31,27 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.phenotips</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>patient-similarity-data-api</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.phenotips</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>patient-similarity-data-impl</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.phenotips</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>patient-network-access-rules</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.phenotips</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>patient-similarity-search</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.phenotips</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>anonymous-communication</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/ui/src/main/resources/PhenoTips/SimilarCases.xml
+++ b/ui/src/main/resources/PhenoTips/SimilarCases.xml
@@ -507,7 +507,7 @@
     },
 
     _displayRemoteContactInfo : function (r) {
-      if (!r.hasOwnProperty("contact") || !r.contact.hasOwnProperty("href") || !r.contact.href) {
+      if (!r.hasOwnProperty("contact") || !r.contact.hasOwnProperty("url") || !r.contact.url) {
         return "No contact info";
       }
       var contactName = r.contact.name;
@@ -533,7 +533,7 @@
         contactLabel = "Anonymous";
       }
       var contactInfo = new Element("a", {
-        "href"  : r.contact.href,
+        "href"  : r.contact.url,
         "title" : "Contact owner for further information",
         "class" : "owner-info "
       }).update(contactLabel);

--- a/ui/src/main/resources/PhenoTips/SimilarCases.xml
+++ b/ui/src/main/resources/PhenoTips/SimilarCases.xml
@@ -507,17 +507,17 @@
     },
 
     _displayRemoteContactInfo : function (r) {
-      if (!r.hasOwnProperty("contact") || !r.contact.hasOwnProperty("url") || !r.contact.url) {
+      if (!r.hasOwnProperty("owner") || !r.owner.hasOwnProperty("url") || !r.owner.url) {
         return "No contact info";
       }
-      var contactName = r.contact.name;
+      var contactName = r.owner.name;
       // Handle GeneMatcher returning "None" as name for organization contacts e.g. GeneDx
       if (contactName == "None") {
         contactName = "";
       }
 
       var hasName = (contactName &amp;&amp; contactName != "");
-      var hasInstitution = (r.contact.institution &amp;&amp; r.contact.institution != "");
+      var hasInstitution = (r.owner.institution &amp;&amp; r.owner.institution != "");
 
       var contactLabel = "";
       if (hasName) {
@@ -527,13 +527,13 @@
         }
       }
       if (hasInstitution) {
-        contactLabel += r.contact.institution;
+        contactLabel += r.owner.institution;
       }
       if (!hasName &amp;&amp; !hasInstitution) {
         contactLabel = "Anonymous";
       }
       var contactInfo = new Element("a", {
-        "href"  : r.contact.url,
+        "href"  : r.owner.url,
         "title" : "Contact owner for further information",
         "class" : "owner-info "
       }).update(contactLabel);


### PR DESCRIPTION
To test PN-161 build in order:
- `phenotips` branch `rm-refactor` on top of milestone-5 with -Pquick
- `patient-network` branch `PN-161` with -Pquick
- `remote-matching` branch `PN-161`
- `phenomecentral`
Create a group with email info. Create and approve new user with email info. Create a new patient as admin, group and as a new user with same candidate gene and any phenotype. Check that `Contact` column for `Similar cases` section is filled in correctly.
Check that matching notification table has contact info filled in correctly.
