### PR TITLE
PN-259: "Matcher run info" document improvement

### DIFF
--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/finder/internal/LocalMatchFinder.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/finder/internal/LocalMatchFinder.java
@@ -36,6 +36,8 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.collections4.CollectionUtils;
+
 /**
  * @version $Id$
  */
@@ -74,6 +76,14 @@ public class LocalMatchFinder extends AbstractMatchFinder implements MatchFinder
         List<PatientMatch> matches = new LinkedList<>();
         for (PatientSimilarityView similarityView : similarPatients) {
             PatientMatch match = new DefaultPatientMatch(similarityView, null, null);
+
+            // filter out matches owned by the same user(s), as those are not shown in matching notification anyway
+            // and they break match count calculation if they are included
+            if (match.getReference().getEmails().size() > 0 && CollectionUtils.isEqualCollection(
+                    match.getReference().getEmails(), match.getMatched().getEmails())) {
+                continue;
+            }
+
             matches.add(match);
         }
         this.matchStorageManager.saveLocalMatches(matches, patient.getId());

--- a/matching-notification-api/src/main/resources/ApplicationResources.properties
+++ b/matching-notification-api/src/main/resources/ApplicationResources.properties
@@ -92,3 +92,7 @@ phenotips.findMatches.refreshMatches.checkbox.label=Run matching search
 
 phenotips.findMatches.refreshMatches.localhost.label=Local matches
 phenotips.findMatches.refreshMatches.selectForSearch=Select for match search
+
+phenotips.findMatches.refreshMatches.lastRunStatus=Last run status
+phenotips.findMatches.refreshMatches.runFinished=Finished
+phenotips.findMatches.refreshMatches.runStillRunningOrCrashed=Not finished

--- a/matching-notification-resources/src/main/resources/resources/uicomponents/matchingNotification/findMatches.css
+++ b/matching-notification-resources/src/main/resources/resources/uicomponents/matchingNotification/findMatches.css
@@ -3,3 +3,23 @@
   margin-left: 1em;
   color: green;
 }
+
+.run-still-running {
+  color: red;
+}
+
+.extradata-list td.server-name {
+  text-align: left;
+  padding-right: 2em;
+}
+
+.extradata-list td.begin-time, .extradata-list td.end-time {
+  text-align: left;
+  padding-right: 25px;
+}
+
+#template('colorThemeInit.vm')
+
+.extradata-list.select-server-row td, .extradata-list.select-server-row th {
+  border-bottom: 1px solid $theme.borderColor;
+}

--- a/matching-notification-ui/src/main/resources/MatchingNotification/MatchingRunInfoClass.xml
+++ b/matching-notification-ui/src/main/resources/MatchingNotification/MatchingRunInfoClass.xml
@@ -101,6 +101,7 @@
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
+      <numberType>integer</numberType>
       <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
     </numPatientsCheckedForMatches>
     <numErrors>
@@ -113,6 +114,7 @@
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
+      <numberType>integer</numberType>
       <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
     </numErrors>
     <totalMatchesFound>
@@ -125,6 +127,7 @@
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
+      <numberType>integer</numberType>
       <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
     </totalMatchesFound>
     <averageTimePerPatient>
@@ -137,6 +140,7 @@
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
+      <numberType>double</numberType>
       <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
     </averageTimePerPatient>
   </class>

--- a/matching-notification-ui/src/main/resources/MatchingNotification/MatchingRunInfoClass.xml
+++ b/matching-notification-ui/src/main/resources/MatchingNotification/MatchingRunInfoClass.xml
@@ -91,17 +91,53 @@
       <validationRegExp/>
       <classType>com.xpn.xwiki.objects.classes.DateClass</classType>
     </startedTime>
-    <numPatientsUsedForLastMatchRun>
+    <numPatientsCheckedForMatches>
       <customDisplay/>
       <disabled>0</disabled>
-      <name>numPatientsUsedForLastMatchRun</name>
+      <name>numPatientsCheckedForMatches</name>
       <number>4</number>
-      <prettyName>Number of local patients updated</prettyName>
+      <prettyName>Number of local patients processed</prettyName>
       <size>8</size>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
       <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
-    </numPatientsUsedForLastMatchRun>
+    </numPatientsCheckedForMatches>
+    <numErrors>
+      <customDisplay/>
+      <disabled>0</disabled>
+      <name>numErrors</name>
+      <number>5</number>
+      <prettyName>Number of errors</prettyName>
+      <size>8</size>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
+    </numErrors>
+    <totalMatchesFound>
+      <customDisplay/>
+      <disabled>0</disabled>
+      <name>totalMatchesFound</name>
+      <number>6</number>
+      <prettyName>Total matches found</prettyName>
+      <size>8</size>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
+    </totalMatchesFound>
+    <averageTimePerPatient>
+      <customDisplay/>
+      <disabled>0</disabled>
+      <name>averageTimePerPatient</name>
+      <number>7</number>
+      <prettyName>Average time per request, sec</prettyName>
+      <size>8</size>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
+    </averageTimePerPatient>
   </class>
 </xwikidoc>

--- a/matching-notification-ui/src/main/resources/MatchingNotification/MatchingUpdateAndInfo.xml
+++ b/matching-notification-ui/src/main/resources/MatchingNotification/MatchingUpdateAndInfo.xml
@@ -43,12 +43,13 @@
   <content>{{include reference="PhenoTips.TabelarDataMacros"/}}
 
 {{velocity}}
-$xwiki.ssfx.use('uicomponents/matchingNotification/findMatches.css')##
+$xwiki.ssfx.use('uicomponents/matchingNotification/findMatches.css', true)##
 $xwiki.jsfx.use('uicomponents/matchingNotification/runtimeConfig.js', true)##
 $xwiki.jsfx.use('uicomponents/matchingNotification/findMatches.js', true)##
 
 #set ($displayDocumentName = 'PhenomeCentral.MatchingUpdateAndInfo')
 $xwiki.ssx.use($displayDocumentName)
+
 #set ($doc = $xwiki.getDocument($displayDocumentName))
 #set ($infoClassname = 'PhenomeCentral.MatchingRunInfoClass')
 #set ($preferenceDoc = $xwiki.getDocument('XWiki.XWikiPreferences'))
@@ -61,17 +62,33 @@ $xwiki.ssx.use($displayDocumentName)
     #set($beginTime = $object.getValue('startedTime'))
     #set($endTime = $object.getValue('completedTime'))
     #set($numPatients = $object.getValue('numPatientsUsedForLastMatchRun'))
+    #if ($endTime.after($beginTime))
+      #set($completed = $services.localization.render('phenotips.findMatches.refreshMatches.runFinished'))
+      #set($completedCSS = 'run-finished-ok')
+    #else
+      #set($completed = $services.localization.render('phenotips.findMatches.refreshMatches.runStillRunningOrCrashed'))
+      #set($completedCSS = 'run-still-running')
+    #end
   #else
     #set($beginTime = '-')
     #set($endTime = '-')
     #set($numPatients = '-')
+    #set($completed = '-')
+    #set($completedCSS = '')
   #end
-  |(% class="server-name" %)$escapetool.xml($serverName)|(% class="begin-time" %)$beginTime|(% class="end-time" %)$endTime|(% class="num-patients" %)$numPatients|(% class="select-for-update" %){{html clean="false" wiki="false"}}&lt;input type="checkbox" value="$serverID"&gt;{{/html}}
+  (% class="extradata-list select-server-row" %)|(% class="server-name" %)$escapetool.xml($serverName)|(% class="begin-time" %)$beginTime|(% class="end-time" %)$endTime|(% class="last-run-status $completedCSS" %)$completed|(% class="select-for-update" %){{html clean="false" wiki="false"}}&lt;input type="checkbox" value="$serverID"&gt;{{/html}}
 #end
 ##
 == $services.localization.render('phenotips.findMatches.refreshMatches.label') ==
-
-(% class="extradata-list" %)#foreach($prop in $dataClass.properties)|=(% class="col-label $prop.name" %)$prop.translatedPrettyName#end|=(% class="col-label select-for-update" %)$services.localization.render('phenotips.findMatches.refreshMatches.selectForSearch')##
+## only some of the properties are displayed in the summary table
+#set ($propertiesInSummaryTable = ['serverName', 'startedTime', 'completedTime'])
+#set ($headerNames = [])
+#foreach($prop in $dataClass.properties)
+  #if ($propertiesInSummaryTable.contains($prop.name))
+    #set($result = $headerNames.add($prop.translatedPrettyName))
+  #end
+#end
+(% class="extradata-list select-server-row" %)#foreach($headerName in $headerNames)|=(% class="col-label" %)$headerName#end|=(% class="col-label last-run-status" %)$services.localization.render('phenotips.findMatches.refreshMatches.lastRunStatus')|=(% class="col-label select-for-update" %)$services.localization.render('phenotips.findMatches.refreshMatches.selectForSearch')##
 
 #set ($localHostObject = $doc.getObject($infoClassname, 'serverName', 'local'))
 #set ($serverName = $services.localization.render('phenotips.findMatches.refreshMatches.localhost.label'))
@@ -81,7 +98,7 @@ $xwiki.ssx.use($displayDocumentName)
 ## only display those which have a non-empty token and the checkbox to show in UI is checked
 ##=======================================
 #foreach ($config in $allRemotes)
-  #if ($config.getProperty('remoteAuthToken').getValue() != "" &amp;&amp; $config.getProperty('serverId').getValue() != "" &amp;&amp; $config.getProperty('includeInUI').getValue() == 1)
+  #if ($config.getProperty('remoteAuthToken').getValue() != "" &amp;&amp; $config.getProperty('serverId').getValue() != "" &amp;&amp; $config.getProperty('searchMatches').getValue() == 1)
     #set ($headerID = "mme-${foreach.count}")
     #set ($serverID = $config.getProperty('serverId').getValue())
     #set ($serverName = $config.getProperty('humanReadableName').getValue())
@@ -90,15 +107,6 @@ $xwiki.ssx.use($displayDocumentName)
       #set ($serverName = $serverID)
     #end
     #set($updateObject = $doc.getObject($infoClassname, 'serverName', $serverID))
-    #if ($updateObject)
-      #set($beginTime = $updateObject.getValue('startedTime'))
-      #set($endTime = $updateObject.getValue('completedTime'))
-      #set($numPatients = $updateObject.getValue('numPatientsUsedForLastMatchRun'))
-    #else
-      #set($beginTime = '-')
-      #set($endTime = '-')
-      #set($numPatients = '-')
-    #end
     #__generateTableRow($serverName $serverID $updateObject)
   #end
 #end
@@ -114,7 +122,13 @@ $xwiki.ssx.use($displayDocumentName)
   &lt;button class="find-matches-button" id="find-updated-matches-button" type="button"&gt;$escapetool.xml($services.localization.render('phenotips.findMatches.refreshMatches.refreshUpdated'))&lt;/button&gt;
   &lt;div class="find-matches-message" id="find-matches-messages"/&gt;
 &lt;/div&gt;
+&lt;br&gt;&lt;br&gt;
 {{/html}}
+
+
+== $services.localization.render('phenotips.findMatches.previousUpdates.label') ==
+
+#__extradata_displayTable($infoClassname, {'counter' : false, 'labels' : false, 'mode' : 'view'})
 
 {{/velocity}}</content>
   <object>


### PR DESCRIPTION
To test: usability of "refresh matches" page; for each run there should be more data printed in a new table below the refresh matches section; for long runs it should mark the server row as "not completed"