### PR TITLE
RM-122: Parse remote patient ID for MyGene2

### DIFF
--- a/matching-notification-resources/src/main/resources/resources/uicomponents/matchingNotification/matchesTable.js
+++ b/matching-notification-resources/src/main/resources/resources/uicomponents/matchingNotification/matchesTable.js
@@ -793,7 +793,14 @@ var PhenoTips = (function (PhenoTips) {
             td += '<a href="' + patientHref + '" target="_blank" class="patient-href">' + patient.patientId + externalId + '</a>';
         } else { // remote patient
             // TODO pass a server name in JSON as well to display a server name instead if server ID in the table
-            td += '<label class="patient-href">' + patient.patientId + externalId + ' (' + patient.serverId + ')</label>';
+            // Parse remote patient ID because MyGene2 uses URLs in the ID field to ensure that the public MyGene2 profiles are actually delivered to the end user
+            if (patient.serverId == "mygene2" && patient.patientId && patient.patientId.startsWith("http")) {
+                var matches = patient.patientId.match(/[\d]+/g);
+                var id = matches ? matches[matches.length - 1] : "$escapetool.javascript($services.localization.render('phenotips.similarCases.profile'))";
+                td += '<a href="' + patient.patientId + '" target="_blank" class="patient-href">' + id + externalId  + ' (' + patient.serverId + ') ' + '</a>';
+            } else {
+                td += '<label class="patient-href">' + patient.patientId + externalId + ' (' + patient.serverId + ')</label>';
+            }
         }
 
         // Collapsible div

--- a/similarity-data-impl/src/main/resources/ApplicationResources.properties
+++ b/similarity-data-impl/src/main/resources/ApplicationResources.properties
@@ -55,6 +55,7 @@ phenotips.similarCases.noVariantInformation=No variant information available
 phenotips.similarCases.undisclosedFeature=undisclosed feature(s)
 phenotips.similarCases.undisclosedPosition=Undisclosed position
 phenotips.similarCases.UCSCGenomeBrowser=Visualize in the UCSC Genome Browser
+phenotips.similarCases.profile=Profile
 
 phenotips.similarCases.error.notAuthenticated=User does not have enough rights to access the patient
 phenotips.similarCases.error.badRequest=The request has invalid syntax

--- a/ui/src/main/resources/PhenoTips/SimilarCases.xml
+++ b/ui/src/main/resources/PhenoTips/SimilarCases.xml
@@ -521,8 +521,11 @@
 
     _displayResultIdentifier : function (r) {
       if (this._mmeMode) {
-        if (r.id &amp;&amp; r.id.startsWith("http")) {
-          return new Element('a', {'href' : r.id}).update("$escapetool.javascript($services.localization.render('phenotips.similarCases.profile'))");
+        // Parse remote patient ID because MyGene2 uses URLs in the ID field to ensure that the public MyGene2 profiles are actually delivered to the end user
+        if (this._mmeServer == "mygene2" &amp;&amp; r.id &amp;&amp; r.id.startsWith("http")) {
+          var matches = r.id.match(/[\d]+/g);
+          var id = matches ? matches[matches.length - 1] : "$escapetool.javascript($services.localization.render('phenotips.similarCases.profile'))";
+          return new Element("a", {href : r.id}).update(id);
         }
         return (r.id ? r.id : "");
       } else {

--- a/ui/src/main/resources/PhenoTips/SimilarCases.xml
+++ b/ui/src/main/resources/PhenoTips/SimilarCases.xml
@@ -521,6 +521,9 @@
 
     _displayResultIdentifier : function (r) {
       if (this._mmeMode) {
+        if (r.id &amp;&amp; r.id.startsWith("http")) {
+          return new Element('a', {'href' : r.id}).update("$escapetool.javascript($services.localization.render('phenotips.similarCases.profile'))");
+        }
         return (r.id ? r.id : "");
       } else {
         return (r.id ? new Element("a", {href : r.url || new XWiki.Document(r.id).getURL()}).update(r.id) : "$escapetool.javascript($services.localization.render('phenotips.similarCases.undisclosedIdentifier'))");


### PR DESCRIPTION
Parse remote patient ID because MyGene2 uses URLs in the ID field to ensure that the public MyGene2 profiles are actually delivered to the end user