### PR TITLE
[misc] Corrected deprecated way to get patient document reference

### DIFF
--- a/matching-notification-ui/src/main/resources/MatchingNotification/AdminMatchNotificationEmailTemplate.xml
+++ b/matching-notification-ui/src/main/resources/MatchingNotification/AdminMatchNotificationEmailTemplate.xml
@@ -119,7 +119,7 @@
          &lt;th style="$grey-background $table"&gt;
             &lt;div style="$subheader"&gt;$!services.localization.render('phenotips.matchingNotifications.email.table.yourPatient.label', 'xhtml/1.0')&lt;/div&gt;
             &lt;div style="$patient-id"&gt;
-               &lt;span&gt;#if($subjectPatientObj)&lt;a href="$xwiki.getDocument($subjectPatientObj.document).getExternalURL()" target="_blank"&gt;$!{escapetool.xml($!subjectPatient.patientId)}&lt;/a&gt;#else$!{escapetool.xml($!subjectPatient.patientId)}#end&lt;/span&gt;
+               &lt;span&gt;#if($subjectPatientObj)&lt;a href="$xwiki.getDocument($subjectPatientObj.getDocumentReference()).getExternalURL()" target="_blank"&gt;$!{escapetool.xml($!subjectPatient.patientId)}&lt;/a&gt;#else$!{escapetool.xml($!subjectPatient.patientId)}#end&lt;/span&gt;
                &lt;span&gt;$!{escapetool.xml($!subjectPatient.externalId)}&lt;/span&gt;
             &lt;/div&gt;
          &lt;/th&gt;


### PR DESCRIPTION
The old way throws log warning `WARN  o.x.v.i.DefaultVelocityEngine  - Deprecated usage of getter [org.phenotips.data.internal.SecurePatient.getDocument] in 66:xwiki:MatchingNotification.AdminMatchNotificationEmailTemplate@28,92 `