### PR TITLE
PN-407: If one of the matches is owned by "nobody", all information starting with the contact column for that match is missing from the Similar cases table

### DIFF
--- a/ui/src/main/resources/PhenoTips/SimilarCases.xml
+++ b/ui/src/main/resources/PhenoTips/SimilarCases.xml
@@ -576,6 +576,9 @@
         }
         return container;
       }
+      if (!r.owner) {
+        return '';
+      }
       var icon = this.Utils.generateIcon('contact', "$escapetool.javascript($services.localization.render('phenotips.similarCases.contactOwnerTitle'))");
       if (r.myCase || !r.owner.email) {
         contactInfo = new Element("span", {"class" : "owner-info"}).insert(r.owner.name || r.owner.id || "").insert(new Element("span", {"class" : this._METADATA_MARKER}));


### PR DESCRIPTION
If case is not solved and there is no owner information, display nothing in the Contact column.