### PR TITLE
PN-425: Better usability of send notifications button

### DIFF
--- a/matching-notification-api/src/main/resources/ApplicationResources.properties
+++ b/matching-notification-api/src/main/resources/ApplicationResources.properties
@@ -65,7 +65,6 @@ phenotips.matchingNotifications.table.modeOfInheritance=Mode of inheritance:
 phenotips.matchingNotifications.table.notObserved=NO
 phenotips.matchingNotifications.table.hasExome.label=VCF uploaded
 phenotips.matchingNotifications.table.notify=Mark match contact to notify
-phenotips.matchingNotifications.table.notify.noContactSelected=No contacts selected for notifying
 phenotips.matchingNotifications.table.saveComment=Save comment
 phenotips.matchingNotifications.table.addComment=Add comment
 phenotips.matchingNotifications.table.notes.title=My notes

--- a/matching-notification-resources/src/main/resources/resources/uicomponents/matchingNotification/matchesTable.js
+++ b/matching-notification-resources/src/main/resources/resources/uicomponents/matchingNotification/matchesTable.js
@@ -543,9 +543,6 @@ var PhenoTips = (function (PhenoTips) {
             this.resultsSummary.hide();
         } else {
             this._matches = this._cachedMatches.filter( (filter) ? filter : this._advancedFilter);
-            if (!this._matches || this._matches.length == 0) {
-                return;
-            }
 
             this.pagination.show();
             this.resultsSummary.show();
@@ -812,7 +809,7 @@ var PhenoTips = (function (PhenoTips) {
         var matchesForPage = this._matches.slice(begin, end);
         this.paginator.refreshPagination(this._maxResults);
 
-        var firstItemRangeNo = begin + 1;
+        var firstItemRangeNo = (end == 0) ? 0 : begin + 1;
         var lastItemRangeNo = end;
         var tableSummary = this._PAGE_COUNT_TEMPLATE.replace(/___caseRange___/g, firstItemRangeNo + "-" + lastItemRangeNo).replace(/___totalCases___/g, this.totalResultsCount).replace(/___numCasesPerPage___/g, "");
         this._displaySummary(tableSummary, $('panels-livetable-limits'), true);

--- a/matching-notification-resources/src/main/resources/resources/uicomponents/matchingNotification/matchesTable.js
+++ b/matching-notification-resources/src/main/resources/resources/uicomponents/matchingNotification/matchesTable.js
@@ -37,6 +37,7 @@ var PhenoTips = (function (PhenoTips) {
 
         $('show-matches-button').on('click', this._showMatches.bind(this));
         this._notificationsButton = $('send-notifications-button');
+        this._notificationsButton.disabled = true;
         this._notificationsButton.hide();
         this._notificationsButton.on('click', this._sendNotification.bind(this));
         $('expand_all').on('click', this._expandAllClicked.bind(this));
@@ -1513,9 +1514,9 @@ var PhenoTips = (function (PhenoTips) {
         $$('input[type=checkbox][class="notify"]').each(function (elm) {
             elm.on('click', function(event) {
                 if (this._getMarkedToNotify().length > 0) {
-                    this._notificationsButton.removeClassName("disabled");
+                    this._notificationsButton.disabled = false;
                 } else {
-                    this._notificationsButton.addClassName("disabled");
+                    this._notificationsButton.disabled = true;
                 }
             }.bind(this));
         }.bind(this));
@@ -1576,27 +1577,17 @@ var PhenoTips = (function (PhenoTips) {
 
     _sendNotification : function(event)
     {
-        event.stop();
-        if (!this._matches) {
+        var matchIDs = this._getMarkedToNotify();
+        if (matchIDs.length == 0) {
             return;
         }
-        var ids = this._getMarkedToNotify();
-        if (ids.length == 0) {
-            this._utils.showFailure('send-notifications-messages', "$escapetool.javascript($services.localization.render('phenotips.matchingNotifications.table.notify.noContactSelected'))");
-            return;
-        }
-        this._notifyMatchByIDs(ids);
-    },
-
-    _notifyMatchByIDs : function(matchIDs)
-    {
         // console.log("Sending " + idsToNotify);
         var idsToNotify = JSON.stringify({ ids: matchIDs});
         new Ajax.Request(this._ajaxURL + 'send-admin-local-notifications', {
             parameters : {'ids' : idsToNotify},
             onCreate : function (response) {
                 // console.log("Notification request sent");
-                this._notificationsButton.addClassName("disabled");
+                this._notificationsButton.disabled = true;
                 this._utils.showSent('send-notifications-messages');
             }.bind(this),
             onSuccess : function (response) {

--- a/matching-notification-ui/src/main/resources/MatchingNotification/MatchesTable.xml
+++ b/matching-notification-ui/src/main/resources/MatchingNotification/MatchesTable.xml
@@ -294,7 +294,7 @@ $xwiki.jsx.use('PhenoTips.Widgets')##
     &lt;br/&gt;
     &lt;div #if(!$hasAdmin)class="hidden"#end&gt;
       &lt;span class="buttonwrapper"&gt;
-        &lt;a class="button" id="send-notifications-button" href="#"&gt;&lt;span class="fa fa-envelope" &gt;&lt;/span&gt;
+        &lt;a class="button disabled" id="send-notifications-button" href="#"&gt;&lt;span class="fa fa-envelope" &gt;&lt;/span&gt;
           &lt;span&gt;$escapetool.xml($services.localization.render('phenotips.matchingNotifications.table.notify.label'))&lt;/span&gt;
         &lt;/a&gt;
       &lt;/span&gt;

--- a/matching-notification-ui/src/main/resources/MatchingNotification/MatchesTable.xml
+++ b/matching-notification-ui/src/main/resources/MatchingNotification/MatchesTable.xml
@@ -294,9 +294,9 @@ $xwiki.jsx.use('PhenoTips.Widgets')##
     &lt;br/&gt;
     &lt;div #if(!$hasAdmin)class="hidden"#end&gt;
       &lt;span class="buttonwrapper"&gt;
-        &lt;a class="button disabled" id="send-notifications-button" href="#"&gt;&lt;span class="fa fa-envelope" &gt;&lt;/span&gt;
+        &lt;button id="send-notifications-button" href="#"&gt;&lt;span class="fa fa-envelope" &gt;&lt;/span&gt;
           &lt;span&gt;$escapetool.xml($services.localization.render('phenotips.matchingNotifications.table.notify.label'))&lt;/span&gt;
-        &lt;/a&gt;
+        &lt;/button&gt;
       &lt;/span&gt;
       &lt;div id="send-notifications-messages"&gt;&lt;/div&gt;
     &lt;/div&gt;


### PR DESCRIPTION
Prevent jumping to the top of the Matching notification page after clicking on SEND NOTIFICATION button
Hide SEND NOTIFICATION button if table is empty
Feedback from sending notification should be close to the button