### PR TITLE
PN-454 Misaligned PubMedIDs on Patient Form

### DIFF
--- a/ui/src/main/resources/PhenoTips/SimilarCases.xml
+++ b/ui/src/main/resources/PhenoTips/SimilarCases.xml
@@ -563,8 +563,8 @@
       // if case is solved - show link to pubmed articles
       if (r.solved &amp;&amp; r.pubmedIds &amp;&amp; r.pubmedIds.size() &gt; 0) {
         var container = new Element("span");
-        var icon = this.Utils.generateIcon('leanpub');
         for (var i=0; i &lt; r.pubmedIds.length; i++) {
+          var icon = this.Utils.generateIcon('leanpub');
           var contactInfo = new Element("a", {
             "href"  : "http://www.ncbi.nlm.nih.gov/pubmed/?term=" + r.pubmedIds[i].trim(),
             "title" : "$escapetool.javascript($services.localization.render('phenotips.similarCases.pubcase.link'))",


### PR DESCRIPTION
This is a very small bug fix where only on the last PubMed ID in the "Similar cases" section had an icon, resulting in minor misalignment.

The `leanpub` icon was created only once outside of the loop, hence it would only appear where it was last attached - the last line. Creating an icon for each PubMed ID line fixes it. Tested directly on browser using dev tools.