### PR TITLE
PN-455: Display the group description instead of ID and full user name in the COMMUNICATION HISTORY of My Matches page

### DIFF
--- a/matching-notification-api/src/main/java/org/phenotips/matchingnotification/notification/internal/AbstractPatientMatchEmail.java
+++ b/matching-notification-api/src/main/java/org/phenotips/matchingnotification/notification/internal/AbstractPatientMatchEmail.java
@@ -489,7 +489,7 @@ public abstract class AbstractPatientMatchEmail implements PatientMatchEmail
         JSONObject info = new JSONObject();
         User user = USERMANAGER.getCurrentUser();
         info.put("id", user.getId());
-        info.put("name", user.getUsername());
+        info.put("name", user.getName());
         info.put("institution", user.getAttribute("company") != null ? user.getAttribute("company").toString() : null);
         return info;
     }


### PR DESCRIPTION
Fixed full user name display in COMMUNICATION HISTORY of My Matches page
Group name part is a bug fixed in PT-3966