### PR TITLE
PN-403: Display current user's patient in left column when we know which of the two local patients in a match belong to the user

### DIFF
--- a/matching-notification-resources/src/main/resources/resources/uicomponents/matchingNotification/matchesTable.js
+++ b/matching-notification-resources/src/main/resources/resources/uicomponents/matchingNotification/matchesTable.js
@@ -656,8 +656,9 @@ var PhenoTips = (function (PhenoTips) {
             // For user only: out of the two patients in a match ("reference" and "matched") returns the one that is "not mine"
             match.notMyCase = (!this._isAdmin) ? this._getNotMyCase(match) : null;
 
-            // swap "reference" and "matched" if they are not in right place based on "notMyCase" if determined
-            if (match.notMyCase != null && match.reference == match.notMyCase) {
+            // swap "reference" and "matched" if both patients in match are local
+            // and they are not in right place based on "notMyCase" if determined
+            if ((match.reference.serverId === '' && match.matched.serverId === '') && match.notMyCase != null && match.reference == match.notMyCase) {
                 match.reference = match.matched;
                 match.matched = match.notMyCase
             }


### PR DESCRIPTION
Swap "reference" and "matched" if both patients in match are local