### PR TITLE
PN-501: Improve the consistency within the matching table UI

### DIFF
--- a/matching-notification-resources/src/main/resources/resources/uicomponents/matchingNotification/matchesTable.js
+++ b/matching-notification-resources/src/main/resources/resources/uicomponents/matchingNotification/matchesTable.js
@@ -1280,10 +1280,6 @@ var PhenoTips = (function (PhenoTips) {
             return null;
         }
 
-        if (this._isAdmin) {
-            return null;
-        }
-
         // determine which of the two patients in match is "my case" and which is "matched case" which should be contacted
         if (match.reference.ownership["userIsOwner"]) {
             // user directly owns "match.reference" => "matched" is match.matched (we know user never owns both patients in a match from this table)


### PR DESCRIPTION
Local patients should always be shown on the left side.